### PR TITLE
Fixed method AppDomainExtensions.LoadAssemblyIntoAppDomain

### DIFF
--- a/src/Catel.Core/Catel.Core.NET40/Reflection/Extensions/AppDomainExtensions.cs
+++ b/src/Catel.Core/Catel.Core.NET40/Reflection/Extensions/AppDomainExtensions.cs
@@ -164,7 +164,7 @@ namespace Catel.Reflection
                     return;
                 }
 
-                var loadedAssembly = Assembly.Load(assemblyName);
+                var loadedAssembly = appDomain.Load(assemblyName);
                 if (includeReferencedAssemblies)
                 {
                     Log.Debug("Loading referenced assemblies of assembly '{0}'", assemblyName);


### PR DESCRIPTION
The assembly should be loaded in the specified AppDomain. Before fix they were loaded into the current one.
