### PR TITLE
ViewModelFactory is now located on first use.

### DIFF
--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Providers/LogicBase.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Providers/LogicBase.cs
@@ -207,7 +207,7 @@ namespace Catel.MVVM.Providers
             {
                 if (_viewModelFactory == null)
                 {
-                    var dependencyResolver = IoCConfiguration.DefaultDependencyResolver;
+                    var dependencyResolver = this.GetDependencyResolver();
                     _viewModelFactory = dependencyResolver.Resolve<IViewModelFactory>();
                 }
                 return _viewModelFactory;


### PR DESCRIPTION
Until now the ViewModelFactory is resolved in static constructor. No chance to register a own ViewModelfactory.
ViewModelFactory is now located on first use on  Property ViewModelFactory in LogicBase.
