### PR TITLE
Fixed SplashScreenService (due to Asynchronisity of UIVisualizerService)

### DIFF
--- a/src/Catel.MVVM/Catel.MVVM.Shared/Services/SplashScreenService.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/Services/SplashScreenService.cs
@@ -431,7 +431,7 @@ namespace Catel.Services
                 _progressNotifyableViewModel = viewModelFunc == null ? null : viewModelFunc.Invoke();
                 if (_progressNotifyableViewModel != null && show)
                 {
-                    _uiVisualizerService.Show(_progressNotifyableViewModel);
+                    _dispatcherService.Invoke(() => _uiVisualizerService.Show(_progressNotifyableViewModel).RunSynchronously());
                 }
 
                 IsCommitting = true;


### PR DESCRIPTION
Fixed: SplashScreenSerivice wouldn't show the SplashScreen after UIVisualizerService became async.
