### PR TITLE
Fixed SplashScreenService due to changes/improvements to the UIVisualizerService

### DIFF
--- a/src/Catel.MVVM/Catel.MVVM.Shared/Services/SplashScreenService.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/Services/SplashScreenService.cs
@@ -431,7 +431,7 @@ namespace Catel.Services
                 _progressNotifyableViewModel = viewModelFunc == null ? null : viewModelFunc.Invoke();
                 if (_progressNotifyableViewModel != null && show)
                 {
-                    _dispatcherService.Invoke(() => _uiVisualizerService.Show(_progressNotifyableViewModel).RunSynchronously());
+                    _dispatcherService.Invoke(() => _uiVisualizerService.Show(_progressNotifyableViewModel));
                 }
 
                 IsCommitting = true;


### PR DESCRIPTION
Fixed SplashScreenService due to changes/improvements to the UIVisualizerService. See CTL-483
SplashScreenService crashed in BeginCommit on the RunSynchronously: RunSynchronously may not be called on a task that was already started.
