### PR TITLE
Fixed property injection with same type and different tag not working.

### DIFF
--- a/src/Catel.Core/Catel.Core.Shared/IoC/ServiceLocator.cs
+++ b/src/Catel.Core/Catel.Core.Shared/IoC/ServiceLocator.cs
@@ -731,7 +731,7 @@ namespace Catel.IoC
 
             lock (this)
             {
-                var typeRequestInfo = new TypeRequestInfo(serviceType);
+                var typeRequestInfo = new TypeRequestInfo(serviceType, tag);
                 if (_currentTypeRequestPath == null)
                 {
                     _currentTypeRequestPath = new TypeRequestPath(typeRequestInfo, name: "ServiceLocator");


### PR DESCRIPTION
Injecting the same interface into a property using the InjectAttribute with a different tag than used for the root object causes an exception when resolving the root object.
As I don't have VS 2013 I can only say that the change works for version 3.9.0.

Demo for test:
```C#
using System;
using Catel.IoC;
namespace CatelTest
{
	class Program
	{
		public static void Main(string[] args)
		{
			var iocContainer = IoCFactory.CreateServiceLocator();
			iocContainer.RegisterTypeWithTag<IService, InitialService>("Initial");
			iocContainer.RegisterTypeWithTag<IService, NormalService>("Normal");
			iocContainer.RegisterType<IService, ServiceChooser>();

			// work around
		//	var svc1 = iocContainer.ResolveType<IService>("Initial");
		//	var svc2 = iocContainer.ResolveType<IService>("Normal");

			var svc = (ServiceChooser)iocContainer.ResolveType<IService>();
			Console.WriteLine(svc.InitialFactory.Name);
			Console.WriteLine(svc.NormalFactory.Name);
			Console.WriteLine(svc.Name);
		}
	}

	public interface IService
	{
		string Name { get; }
	}
	public class ServiceChooser : IService
	{
		[Inject(typeof(IService), "Initial")]
		public IService InitialFactory { get; set; }
		[Inject(typeof(IService), "Normal")]
		public IService NormalFactory { get; set; }
		public string Name { get { return "chooser"; } }
	}
	public class InitialService : IService
	{
		public string Name { get { return "initial"; } }
	}
	public class NormalService : IService
	{
		public string Name { get { return "normal"; } }
	}
}
```

