### PR TITLE
Enable TaskCommands and ProgressiveTaskCommands in SL and NET40

### DIFF
--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Commands/EventArgs/CommandProgressChangedEventArgs.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Commands/EventArgs/CommandProgressChangedEventArgs.cs
@@ -4,8 +4,6 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-#if !NET40 && !SILVERLIGHT
-
 namespace Catel.MVVM
 {
     using System;
@@ -30,5 +28,3 @@ namespace Catel.MVVM
         public TProgress Progress { get; set; }
     }
 }
-
-#endif

--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Commands/Interfaces/ICatelTaskCommand.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Commands/Interfaces/ICatelTaskCommand.cs
@@ -4,8 +4,6 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-#if !NET40 && !SILVERLIGHT
-
 namespace Catel.MVVM
 {
     using System;
@@ -62,5 +60,3 @@ namespace Catel.MVVM
         event EventHandler<CommandProgressChangedEventArgs<TProgress>> ProgressChanged;
     }
 }
-
-#endif

--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Commands/Interfaces/ITaskProgressReport.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Commands/Interfaces/ITaskProgressReport.cs
@@ -4,8 +4,6 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-#if !NET40 && !SILVERLIGHT
-
 namespace Catel.MVVM
 {
     /// <summary>
@@ -22,5 +20,3 @@ namespace Catel.MVVM
         #endregion
     }
 }
-
-#endif

--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Commands/TaskCommand.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Commands/TaskCommand.cs
@@ -43,7 +43,7 @@ namespace Catel.MVVM
         /// Initializes a new instance of the <see cref="Catel.MVVM.TaskCommand{TExecuteParameter,TCanExecuteParameter, TProgress}" /> class.
         /// </summary>
         /// <param name="execute">The action to execute.</param>
-        /// <param name="canExecute">The function to call to determine wether the command can be executed.</param>
+        /// <param name="canExecute">The function to call to determine whether the command can be executed.</param>
         /// <param name="tag">The tag of the command.</param>
         public TaskCommand(Func<Task> execute, Func<bool> canExecute = null, object tag = null)
             : this(canExecuteWithoutParameter: canExecute, tag: tag)
@@ -55,7 +55,7 @@ namespace Catel.MVVM
         /// Initializes a new instance of the <see cref="Catel.MVVM.TaskCommand{TExecuteParameter,TCanExecuteParameter, TProgress}" /> class.
         /// </summary>
         /// <param name="execute">The action to execute.</param>
-        /// <param name="canExecute">The function to call to determine wether the command can be executed.</param>
+        /// <param name="canExecute">The function to call to determine whether the command can be executed.</param>
         /// <param name="tag">The tag of the command.</param>
         public TaskCommand(Func<CancellationToken, Task> execute, Func<bool> canExecute = null, object tag = null)
             : this(canExecuteWithoutParameter: canExecute, tag: tag)
@@ -67,7 +67,7 @@ namespace Catel.MVVM
         /// Initializes a new instance of the <see cref="Catel.MVVM.TaskCommand{TExecuteParameter,TCanExecuteParameter, TProgress}" /> class.
         /// </summary>
         /// <param name="execute">The action to execute.</param>
-        /// <param name="canExecute">The function to call to determine wether the command can be executed.</param>
+        /// <param name="canExecute">The function to call to determine whether the command can be executed.</param>
         /// <param name="reportProgress">Action is executed each time task progress is reported.</param>
         /// <param name="tag">The tag of the command.</param>
         public TaskCommand(Func<CancellationToken, IProgress<TProgress>, Task> execute, Func<bool> canExecute = null, Action<TProgress> reportProgress = null, object tag = null)
@@ -80,7 +80,7 @@ namespace Catel.MVVM
         /// Initializes a new instance of the <see cref="Catel.MVVM.TaskCommand{TExecuteParameter,TCanExecuteParameter, TProgress}" /> class.
         /// </summary>
         /// <param name="execute">The action to execute.</param>
-        /// <param name="canExecute">The function to call to determine wether the command can be executed.</param>
+        /// <param name="canExecute">The function to call to determine whether the command can be executed.</param>
         /// <param name="tag">The tag of the command.</param>
         public TaskCommand(Func<TExecuteParameter, Task> execute, Func<TCanExecuteParameter, bool> canExecute = null, object tag = null)
             : this(canExecuteWithParameter: canExecute, tag: tag)
@@ -92,7 +92,7 @@ namespace Catel.MVVM
         /// Initializes a new instance of the <see cref="Catel.MVVM.TaskCommand{TExecuteParameter,TCanExecuteParameter, TProgress}" /> class.
         /// </summary>
         /// <param name="execute">The action to execute.</param>
-        /// <param name="canExecute">The function to call to determine wether the command can be executed.</param>
+        /// <param name="canExecute">The function to call to determine whether the command can be executed.</param>
         /// <param name="tag">The tag of the command.</param>
         public TaskCommand(Func<TExecuteParameter, CancellationToken, Task> execute, Func<TCanExecuteParameter, bool> canExecute = null, object tag = null)
             : this(canExecuteWithParameter: canExecute, tag: tag)
@@ -105,7 +105,7 @@ namespace Catel.MVVM
         /// <see cref="Catel.MVVM.TaskCommand{TExecuteParameter,TCanExecuteParameter, TProgress}" /> class.
         /// </summary>
         /// <param name="execute">The action to execute.</param>
-        /// <param name="canExecute">The function to call to determine wether the command can be executed.</param>
+        /// <param name="canExecute">The function to call to determine whether the command can be executed.</param>
         /// <param name="reportProgress">Action is executed each time task progress is reported.</param>
         /// <param name="tag">The tag of the command.</param>
         public TaskCommand(Func<TExecuteParameter, CancellationToken, IProgress<TProgress>, Task> execute, Func<TCanExecuteParameter, bool> canExecute = null,
@@ -119,9 +119,9 @@ namespace Catel.MVVM
         /// Initializes a new instance of the
         /// <see cref="Catel.MVVM.TaskCommand{TExecuteParameter,TCanExecuteParameter, TProgress}" /> class.
         /// </summary>
-        /// <param name="canExecuteWithParameter">The function to call to determine wether the command can be executed with
+        /// <param name="canExecuteWithParameter">The function to call to determine whether the command can be executed with
         /// parameter.</param>
-        /// <param name="canExecuteWithoutParameter">The function to call to determine wether the command can be executed without
+        /// <param name="canExecuteWithoutParameter">The function to call to determine whether the command can be executed without
         /// parameter.</param>
         /// <param name="reportProgress">Action is executed each time task progress is reported.</param>
         /// <param name="tag">The tag of the command.</param>
@@ -320,7 +320,7 @@ namespace Catel.MVVM
         /// Initializes a new instance of the <see cref="TaskCommand{TExecuteParameter}" /> class.
         /// </summary>
         /// <param name="execute">The action to execute.</param>
-        /// <param name="canExecute">The function to call to determine wether the command can be executed.</param>
+        /// <param name="canExecute">The function to call to determine whether the command can be executed.</param>
         /// <param name="tag">The tag of the command.</param>
         public TaskCommand(Func<TExecuteParameter, Task> execute, Func<TExecuteParameter, bool> canExecute = null, object tag = null)
             : base(execute, canExecute, tag)
@@ -331,7 +331,7 @@ namespace Catel.MVVM
         /// Initializes a new instance of the <see cref="TaskCommand{TExecuteParameter}" /> class.
         /// </summary>
         /// <param name="execute">The action to execute.</param>
-        /// <param name="canExecute">The function to call to determine wether the command can be executed.</param>
+        /// <param name="canExecute">The function to call to determine whether the command can be executed.</param>
         /// <param name="tag">The tag of the command.</param>
         public TaskCommand(Func<TExecuteParameter, CancellationToken, Task> execute, Func<TExecuteParameter, bool> canExecute = null, object tag = null)
             : base(execute, canExecute, tag)
@@ -351,7 +351,7 @@ namespace Catel.MVVM
         /// Initializes a new instance of the <see cref="Catel.MVVM.TaskCommand" /> class.
         /// </summary>
         /// <param name="execute">The action to execute.</param>
-        /// <param name="canExecute">The function to call to determine wether the command can be executed.</param>
+        /// <param name="canExecute">The function to call to determine whether the command can be executed.</param>
         /// <param name="tag">The tag of the command.</param>
         public TaskCommand(Func<Task> execute, Func<bool> canExecute = null, object tag = null)
             : base(execute, canExecute, tag)
@@ -362,7 +362,7 @@ namespace Catel.MVVM
         /// Initializes a new instance of the <see cref="Catel.MVVM.TaskCommand" /> class.
         /// </summary>
         /// <param name="execute">The action to execute.</param>
-        /// <param name="canExecute">The function to call to determine wether the command can be executed.</param>
+        /// <param name="canExecute">The function to call to determine whether the command can be executed.</param>
         /// <param name="tag">The tag of the command.</param>
         public TaskCommand(Func<CancellationToken, Task> execute, Func<bool> canExecute = null, object tag = null)
             : base(execute, canExecute, tag)
@@ -386,7 +386,7 @@ namespace Catel.MVVM
         /// Initializes a new instance of the <see cref="ProgressiveTaskCommand{TProgress, TExecuteParameter}" /> class.
         /// </summary>
         /// <param name="execute">The action to execute.</param>
-        /// <param name="canExecute">The function to call to determine wether the command can be executed.</param>
+        /// <param name="canExecute">The function to call to determine whether the command can be executed.</param>
         /// <param name="reportProgress">Action is executed each time task progress is reported.</param>
         /// <param name="tag">The tag of the command.</param>
         public ProgressiveTaskCommand(Func<CancellationToken, IProgress<TProgress>, Task> execute, Func<bool> canExecute = null, Action<TProgress> reportProgress = null, object tag = null)
@@ -409,7 +409,7 @@ namespace Catel.MVVM
         /// Initializes a new instance of the <see cref="TaskCommand{TExecuteParameter}" /> class.
         /// </summary>
         /// <param name="execute">The action to execute.</param>
-        /// <param name="canExecute">The function to call to determine wether the command can be executed.</param>
+        /// <param name="canExecute">The function to call to determine whether the command can be executed.</param>
         /// <param name="reportProgress">Action is executed each time task progress is reported.</param>
         /// <param name="tag">The tag of the command.</param>
         public ProgressiveTaskCommand(Func<CancellationToken, IProgress<TProgress>, Task> execute, Func<bool> canExecute = null, Action<TProgress> reportProgress = null, object tag = null)

--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Commands/TaskCommand.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Commands/TaskCommand.cs
@@ -4,13 +4,15 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-#if !NET40 && !SILVERLIGHT
-
 namespace Catel.MVVM
 {
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+
+#if NET40 || SILVERLIGHT
+    using Microsoft;
+#endif
 
     using Catel.Logging;
 
@@ -417,5 +419,3 @@ namespace Catel.MVVM
         #endregion
     }
 }
-
-#endif

--- a/src/Catel.Test/Catel.Test.Shared/MVVM/Commands/TaskCommandFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/MVVM/Commands/TaskCommandFacts.cs
@@ -4,7 +4,7 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-#if NET45 || NET40
+#if NET
 
 namespace Catel.Test.MVVM.Commands
 {
@@ -13,6 +13,7 @@ namespace Catel.Test.MVVM.Commands
     using System.Threading.Tasks;
 
     using Catel.MVVM;
+    using Catel.Threading;
 
     using NUnit.Framework;
 
@@ -25,7 +26,7 @@ namespace Catel.Test.MVVM.Commands
 
         #region Methods
         [TestCase]
-        public async Task TestCommandCancellation()
+        public void TestCommandCancellation()
         {
             var taskCommand = new TaskCommand(TestExecute);
 
@@ -35,19 +36,13 @@ namespace Catel.Test.MVVM.Commands
             taskCommand.Execute();
 
             Assert.IsTrue(taskCommand.IsExecuting);
-#if NET40
-            await TaskEx.Delay(TimeSpan.FromSeconds(1));
-#else
-            await Task.Delay(TimeSpan.FromSeconds(1));
-#endif
+
+            ThreadHelper.Sleep(1000);
 
             taskCommand.Cancel();
 
-#if NET40
-            await TaskEx.Delay(TimeSpan.FromSeconds(1));
-#else
-            await Task.Delay(TimeSpan.FromSeconds(1));
-#endif
+            ThreadHelper.Sleep(1000);
+
             Assert.IsFalse(taskCommand.IsExecuting);
             Assert.IsFalse(taskCommand.IsCancellationRequested);
         }

--- a/src/Catel.Test/Catel.Test.Shared/MVVM/Commands/TaskCommandFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/MVVM/Commands/TaskCommandFacts.cs
@@ -4,7 +4,7 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-#if NET45
+#if NET45 || NET40
 
 namespace Catel.Test.MVVM.Commands
 {
@@ -35,11 +35,19 @@ namespace Catel.Test.MVVM.Commands
             taskCommand.Execute();
 
             Assert.IsTrue(taskCommand.IsExecuting);
+#if NET40
+            await TaskEx.Delay(TimeSpan.FromSeconds(1));
+#else
             await Task.Delay(TimeSpan.FromSeconds(1));
+#endif
 
             taskCommand.Cancel();
 
+#if NET40
+            await TaskEx.Delay(TimeSpan.FromSeconds(1));
+#else
             await Task.Delay(TimeSpan.FromSeconds(1));
+#endif
             Assert.IsFalse(taskCommand.IsExecuting);
             Assert.IsFalse(taskCommand.IsCancellationRequested);
         }
@@ -48,7 +56,11 @@ namespace Catel.Test.MVVM.Commands
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+#if NET40
+            await TaskEx.Delay(TaskDelay, cancellationToken);
+#else
             await Task.Delay(TaskDelay, cancellationToken);
+#endif
 
             cancellationToken.ThrowIfCancellationRequested();
         }


### PR DESCRIPTION
Enables the TaskCommands and ProgressiveTaskCommands for SL and NET40. According to the comments in the task CT-135, it seems like SL and NET40 were excluded from the implementation do to the desire not to take a dependency on the Microsoft.Bcl.Async library. The project has since taken on that dependency.