### PR TITLE
Using Xamarin.Forms.IValueConverter as a base interface for Catel.MVV…

### DIFF
--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Converters/Interfaces/IValueConverter.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Converters/Interfaces/IValueConverter.cs
@@ -7,43 +7,17 @@
 
 namespace Catel.MVVM.Converters
 {
-#if XAMARIN
-    using System;
-    using System.Globalization;
-#endif
-
     /// <summary>
     /// Interface for all value converters.
     /// </summary>
     public interface IValueConverter 
 #if XAMARIN
-        // No base class
+        : Xamarin.Forms.IValueConverter
 #elif NETFX_CORE
         : global::Windows.UI.Xaml.Data.IValueConverter
 #else
         : System.Windows.Data.IValueConverter
 #endif
     {
-#if XAMARIN
-        /// <summary>
-        /// Modifies the source data before passing it to the target for display in the UI.
-        /// </summary>
-        /// <param name="value">The source data being passed to the target.</param>
-        /// <param name="targetType">The <see cref="T:System.Type" /> of data expected by the target dependency property.</param>
-        /// <param name="parameter">An optional parameter to be used in the converter logic.</param>
-        /// <param name="culture">The culture of the conversion.</param>
-        /// <returns>The value to be passed to the target dependency property.</returns>
-        object Convert(object value, Type targetType, object parameter, CultureInfo culture);
-
-        /// <summary>
-        /// Modifies the target data before passing it to the source object.
-        /// </summary>
-        /// <param name="value">The target data being passed to the source.</param>
-        /// <param name="targetType">The <see cref="T:System.Type" /> of data expected by the source object.</param>
-        /// <param name="parameter">An optional parameter to be used in the converter logic.</param>
-        /// <param name="culture">The culture of the conversion.</param>
-        /// <returns>The value to be passed to the source object.</returns>
-        object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture);
-#endif
     }
 }


### PR DESCRIPTION
…M.Converters.IValueConverter

Might be I'm missing something, but Xamarin.Forms.IValueConverter is used in an exactly the same way as System.Windows.Data.IValueConverter in WPF. Why not inherit it then?

Disclaim: I didn't even tried to compile Catel with this change, just want to discuss the possibility of that change. I think it should be a reason why it was not made already.