### PR TITLE
handle PreviewKeyDown event instead of KeyDown in CommandManagerWrapper

### DIFF
--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Commands/CommandManagerWrapper.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Commands/CommandManagerWrapper.cs
@@ -64,9 +64,11 @@ namespace Catel.MVVM
             {
                 return;
             }
-
+#if SL5
             View.KeyDown += OnKeyDown;
-
+#else
+            View.PreviewKeyDown += OnKeyDown;
+#endif
             _subscribed = true;
         }
 
@@ -77,7 +79,11 @@ namespace Catel.MVVM
                 return;
             }
 
+#if SL5
             View.KeyDown -= OnKeyDown;
+#else
+            View.PreviewKeyDown -= OnKeyDown;
+#endif
 
             _subscribed = false;
         }


### PR DESCRIPTION
this allows to override already defined shortcuts (such as Ctrl + Tab in TabControl, Space on Buttons, ...) 