### PR TITLE
Added support of Android's ISharedPreferences in ConfigurationService

### DIFF
--- a/src/Catel.Core/Catel.Core.Shared/Configuration/ConfigurationService.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Configuration/ConfigurationService.cs
@@ -43,6 +43,9 @@ namespace Catel.Configuration
 #if NET
         private readonly DynamicConfiguration _configuration;
         private readonly string _configFilePath;
+#elif ANDROID
+        private readonly global::Android.Content.ISharedPreferences _preferences =
+            global::Android.Preferences.PreferenceManager.GetDefaultSharedPreferences(global::Android.App.Application.Context);
 #endif
 
         private bool _suspendNotifications = false;
@@ -208,8 +211,10 @@ namespace Catel.Configuration
         /// <returns><c>true</c> if the value exists, <c>false</c> otherwise.</returns>
         protected virtual bool ValueExists(string key)
         {
-#if PCL || XAMARIN
+#if PCL || (XAMARIN && !ANDROID)
             throw new NotSupportedInPlatformException();
+#elif ANDROID
+            return _preferences.Contains(key);
 #elif NETFX_CORE
             var settings = ApplicationData.Current.RoamingSettings;
             return settings.Values.ContainsKey(key);
@@ -228,8 +233,10 @@ namespace Catel.Configuration
         /// <returns>The value.</returns>
         protected virtual string GetValueFromStore(string key)
         {
-#if PCL || XAMARIN
+#if PCL || (XAMARIN && !ANDROID)
             throw new NotSupportedInPlatformException();
+#elif ANDROID
+            return _preferences.GetString(key, null);
 #elif NETFX_CORE
             var settings = ApplicationData.Current.RoamingSettings;
             return (string)settings.Values[key];
@@ -248,8 +255,12 @@ namespace Catel.Configuration
         /// <param name="value">The value.</param>
         protected virtual void SetValueToStore(string key, string value)
         {
-#if PCL || XAMARIN
+#if PCL || (XAMARIN && !ANDROID)
             throw new NotSupportedInPlatformException();
+#elif ANDROID
+            _preferences.Edit()
+                        .PutString(key, value)
+                        .Apply();
 #elif NETFX_CORE
             var settings = ApplicationData.Current.RoamingSettings;
             settings.Values[key] = value;


### PR DESCRIPTION
I just found that ConfigurationService does not support Android yet. It looks like it can be extremly easy fixed. If you have nothing against my fix, it would be great, if it can be merged into the next release.

PS. I would like to add some tests, if needed, but I could not found any for Android.