### PR TITLE
CTL-720 Update ChangeNotificationWrapper.cs

### DIFF
--- a/src/Catel.Core/Catel.Core.Shared/Data/ChangeNotificationWrapper.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Data/ChangeNotificationWrapper.cs
@@ -498,7 +498,7 @@ namespace Catel.Data
                 }
 
                 IWeakEventListener oldSubscription;
-                if (eventsTable.TryGetValue(value, out oldSubscription))
+                if (eventsTable != null && eventsTable.TryGetValue(value, out oldSubscription))
                 {
                     oldSubscription.Detach();
 


### PR DESCRIPTION
I hit an unhandled exception of type 'System.NullReferenceException' occurred in Catel.Core.dll at that place and was due to the fact that eventsTable happened to be null.