### PR TITLE
UpdatableMarkupExtension doesn't expose IServiceProvider in the ProvideDynamicValue method

### DIFF
--- a/src/Catel.MVVM/Catel.MVVM.Shared/Windows/Markup/CommandManagerBinding.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/Windows/Markup/CommandManagerBinding.cs
@@ -87,7 +87,7 @@ namespace Catel.Windows.Markup
         /// Provides the dynamic value.
         /// </summary>
         /// <returns>System.Object.</returns>
-        protected override object ProvideDynamicValue()
+        protected override object ProvideDynamicValue(IServiceProvider serviceProvider)
         {
             if (_commandManager == null)
             {

--- a/src/Catel.MVVM/Catel.MVVM.Shared/Windows/Markup/LanguageBinding.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/Windows/Markup/LanguageBinding.cs
@@ -79,7 +79,7 @@ namespace Catel.Windows.Markup
         /// When implemented in a derived class, returns an object that is provided as the value of the target property for this markup extension.
         /// </summary>
         /// <returns>The object value to set on the property where the extension is applied.</returns>
-        protected override object ProvideDynamicValue()
+        protected override object ProvideDynamicValue(IServiceProvider serviceProvider)
         {
             if (_languageService == null)
             {

--- a/src/Catel.MVVM/Catel.MVVM.Shared/Windows/Markup/UpdatableMarkupExtension.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/Windows/Markup/UpdatableMarkupExtension.cs
@@ -35,6 +35,7 @@ namespace Catel.Windows.Markup
         private object _targetObject;
         private object _targetProperty;
         private bool _isFrameworkElementLoaded;
+        private IServiceProvider _serviceProvider;
         #endregion
 
         #region Constructors
@@ -71,7 +72,9 @@ namespace Catel.Windows.Markup
 #if WINDOWS_PHONE || NETFX_CORE
             _targetObject = null;
             _targetProperty = null;
+            _serviceProvider = null;
 #else
+            _serviceProvider = serviceProvider;
             var target = serviceProvider.GetService(typeof(IProvideValueTarget)) as IProvideValueTarget;
             if (target != null)
             {
@@ -115,7 +118,7 @@ namespace Catel.Windows.Markup
             }
 #endif
 
-            var dynamicValue = ProvideDynamicValue();
+            var dynamicValue = ProvideDynamicValue(serviceProvider);
             return dynamicValue;
         }
 
@@ -166,7 +169,7 @@ namespace Catel.Windows.Markup
         /// </summary>
         protected void UpdateValue()
         {
-            var value = ProvideDynamicValue();
+            var value = ProvideDynamicValue(_serviceProvider);
 
             if (_targetObject != null)
             {
@@ -218,7 +221,7 @@ namespace Catel.Windows.Markup
         /// Provides the dynamic value.
         /// </summary>
         /// <returns>System.Object.</returns>
-        protected abstract object ProvideDynamicValue();
+        protected abstract object ProvideDynamicValue(IServiceProvider serviceProvider);
         #endregion
     }
 }


### PR DESCRIPTION
Changed the UpdatableMarkupExtension class to include the IServiceProvider.

Remarks:

- I had to assign the serviceProvider to a private field in order to be able to access it from the UpdateValue method
- This is a breaking change as the method signature has changed. Therefore I updated the CommandManagerBinding and the LanguageBinding class as these override the method.
- To prevent breaking changes, you could opt to not change the method signature and expose the service as a read only property. I think passing it to the method as a parameter is better as it's style is similar to the original MarkupExtension class, preventing confusion and making it more visible.

- I DID NOT TEST OR BUILD THIS. As i'm currently technically incapable of installing all Catel's dependencies due to disk space. Sorry about that