### PR TITLE
Small improvements to AreEqualMultiValueConverter

### DIFF
--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Converters/AreEqualMultiValueConverter.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Converters/AreEqualMultiValueConverter.cs
@@ -10,13 +10,14 @@ namespace Catel.MVVM.Converters
 {
     using System;
     using System.Windows.Data;
+    using System.Windows.Markup;
 
     /// <summary>
     /// Converts a comparison of 2 bindings to a boolean whether the 
     /// objects are equal or not.
     /// </summary>
     [ValueConversion(typeof(object), typeof(object))]
-    public class AreEqualMultiValueConverter : IMultiValueConverter
+    public class AreEqualMultiValueConverter : MarkupExtension, IMultiValueConverter
     {
         /// <summary>
         /// Converts the comparison of 2 values to a boolean.
@@ -61,6 +62,16 @@ namespace Catel.MVVM.Converters
         {
             // Not supported (and IMultiValueConverter must return null if no conversion is supported)
             return null;
+        }
+
+        /// <summary>
+        /// When implemented in a derived class, returns an object that is set as the value of the target property for this markup extension.
+        /// </summary>
+        /// <param name="serviceProvider">Object that can provide services for the markup extension.</param>
+        /// <returns>The object value to set on the property where the extension is applied.</returns>
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return this;
         }
     }
 }

--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Converters/AreEqualMultiValueConverter.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Converters/AreEqualMultiValueConverter.cs
@@ -34,20 +34,7 @@ namespace Catel.MVVM.Converters
                 return false;
             }
 
-            object value1 = values[0];
-            object value2 = values[1];
-
-            if ((value1 == null) && (value2 == null))
-            {
-                return true;
-            }
-
-            if ((value1 == null) || (value2 == null))
-            {
-                return false;
-            }
-
-            return value1.Equals(value2);
+            return object.Equals(values[0], values[1]);
         }
 
         /// <summary>


### PR DESCRIPTION
I make it MarkupExtension so now it'll be visible in XAML editor.
Simplified equals code as this is the same code that is used by object.Equals static method with small difference that object.Equals checks first for reference equality before checking if values are Equal.