### PR TITLE
Add GetDynamicMemberNames() method to DynamicObservableObjectMetaObject

### DIFF
--- a/src/Catel.Extensions.DynamicObjects/Catel.Extensions.DynamicObjects.Shared/Data/DynamicObservableObject.cs
+++ b/src/Catel.Extensions.DynamicObjects/Catel.Extensions.DynamicObjects.Shared/Data/DynamicObservableObject.cs
@@ -9,6 +9,7 @@ namespace Catel.Data
     using System;
     using System.Collections.Generic;
     using System.Dynamic;
+    using System.Linq;
     using System.Linq.Expressions;
 
     /// <summary>
@@ -64,6 +65,15 @@ namespace Catel.Data
         public DynamicMetaObject GetMetaObject(Expression parameter)
         {
             return new DynamicObservableObjectMetaObject(parameter, this);
+        }
+
+        /// <summary>
+        /// Returns the enumeration of all property names.
+        /// </summary>
+        /// <returns>The list of property names.</returns>
+        protected internal IEnumerable<string> GetPropertyNames()
+        {
+            return new List<string>(_dynamicProperties.Keys);
         }
     }
 }

--- a/src/Catel.Extensions.DynamicObjects/Catel.Extensions.DynamicObjects.Shared/Data/DynamicObservableObjectMetaObject.cs
+++ b/src/Catel.Extensions.DynamicObjects/Catel.Extensions.DynamicObjects.Shared/Data/DynamicObservableObjectMetaObject.cs
@@ -8,8 +8,10 @@ namespace Catel.Data
 {
     using Reflection;
     using System.Dynamic;
+    using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Class containing metadata for the <see cref="DynamicObservableObject"/>.
@@ -18,6 +20,7 @@ namespace Catel.Data
     {
         private static readonly MethodInfo _getValueMethodInfo;
         private static readonly MethodInfo _setValueMethodInfo;
+        private static readonly FieldInfo _getPropertiesNamesFieldInfo;
 
         /// <summary>
         /// Initializes static members of the <see cref=" DynamicObservableObjectMetaObject"/> class.
@@ -28,6 +31,10 @@ namespace Catel.Data
 
             _getValueMethodInfo = typeof(DynamicObservableObject).GetMethodEx("GetValue", bindingFlags).MakeGenericMethod(new[] { typeof(object) });
             _setValueMethodInfo = typeof(DynamicObservableObject).GetMethodEx("SetValue", bindingFlags);
+
+            bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic;
+
+            _getPropertiesNamesFieldInfo = typeof(DynamicObservableObject).GetFieldEx("_dynamicProperties", bindingFlags);
         }
 
         /// <summary>
@@ -39,6 +46,15 @@ namespace Catel.Data
             : base(parameter, BindingRestrictions.Empty, observableObject)
         {
 
+        }
+
+        /// <summary>
+        /// Returns the enumeration of all dynamic member names.
+        /// </summary>
+        /// <returns>The list of dynamic member names.</returns>
+        public override IEnumerable<string> GetDynamicMemberNames()
+        {
+            return ((IDictionary<string, object>)_getPropertiesNamesFieldInfo.GetValue(Value)).Keys.ToList();
         }
 
         /// <summary>

--- a/src/Catel.Extensions.DynamicObjects/Catel.Extensions.DynamicObjects.Shared/Data/DynamicObservableObjectMetaObject.cs
+++ b/src/Catel.Extensions.DynamicObjects/Catel.Extensions.DynamicObjects.Shared/Data/DynamicObservableObjectMetaObject.cs
@@ -7,11 +7,10 @@
 namespace Catel.Data
 {
     using Reflection;
+    using System.Collections.Generic;
     using System.Dynamic;
-    using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
-    using System.Collections.Generic;
 
     /// <summary>
     /// Class containing metadata for the <see cref="DynamicObservableObject"/>.
@@ -20,7 +19,6 @@ namespace Catel.Data
     {
         private static readonly MethodInfo _getValueMethodInfo;
         private static readonly MethodInfo _setValueMethodInfo;
-        private static readonly FieldInfo _getPropertiesNamesFieldInfo;
 
         /// <summary>
         /// Initializes static members of the <see cref=" DynamicObservableObjectMetaObject"/> class.
@@ -31,10 +29,6 @@ namespace Catel.Data
 
             _getValueMethodInfo = typeof(DynamicObservableObject).GetMethodEx("GetValue", bindingFlags).MakeGenericMethod(new[] { typeof(object) });
             _setValueMethodInfo = typeof(DynamicObservableObject).GetMethodEx("SetValue", bindingFlags);
-
-            bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic;
-
-            _getPropertiesNamesFieldInfo = typeof(DynamicObservableObject).GetFieldEx("_dynamicProperties", bindingFlags);
         }
 
         /// <summary>
@@ -54,7 +48,7 @@ namespace Catel.Data
         /// <returns>The list of dynamic member names.</returns>
         public override IEnumerable<string> GetDynamicMemberNames()
         {
-            return ((IDictionary<string, object>)_getPropertiesNamesFieldInfo.GetValue(Value)).Keys.ToList();
+            return ((DynamicObservableObject)Value).GetPropertyNames();
         }
 
         /// <summary>


### PR DESCRIPTION
Hi,

As title says I added GetDynamicMemberNames() to DynamicObservableObjectMetaObject. So now we can get dynamic member names for DynamicObservableObject.