### PR TITLE
FastBindingList bug fixes

### DIFF
--- a/src/Catel.MVVM/Catel.MVVM.Shared/Catel.MVVM.Shared.projitems
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/Catel.MVVM.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CatelEnvironment.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Collections\Enums\NotifyRangedListChangedAction.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Collections\EventArgs\NotifyListChangedEventArgs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Collections\EventArgs\NotifyRangedCollectionChangedEventArgs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Collections\EventArgs\NotifyRangedListChangedEventArgs.cs" />

--- a/src/Catel.MVVM/Catel.MVVM.Shared/Collections/Enums/NotifyRangedListChangedAction.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/Collections/Enums/NotifyRangedListChangedAction.cs
@@ -1,0 +1,33 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="NotifyRangedListChangedAction.cs" company="Catel development team">
+//   Copyright (c) 2008 - 2016 Catel development team. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+#if NET
+
+namespace Catel.Collections
+{
+    /// <summary>
+    /// Describes the real action performed on the <see cref="FastBindingList{T}"/>. 
+    /// </summary>
+    public enum NotifyRangedListChangedAction
+    {
+        /// <summary>
+        /// Items was added to the <see cref="FastBindingList{T}"/>.
+        /// </summary>
+        Add,
+
+        /// <summary>
+        /// Items was removed from the <see cref="FastBindingList{T}"/>.
+        /// </summary>
+        Remove,
+
+        /// <summary>
+        /// The <see cref="FastBindingList{T}"/> has been reset.
+        /// </summary>
+        Reset
+    }
+}
+
+#endif

--- a/src/Catel.MVVM/Catel.MVVM.Shared/Collections/EventArgs/NotifyRangedListChangedEventArgs.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/Collections/EventArgs/NotifyRangedListChangedEventArgs.cs
@@ -20,10 +20,12 @@ namespace Catel.Collections
         /// <summary>
         /// Initializes a new instance of the <see cref="NotifyRangedListChangedEventArgs"/> class.
         /// </summary>
-        /// <param name="listChangedType">Type of change.</param>
-        public NotifyRangedListChangedEventArgs(ListChangedType listChangedType)
-            : base(listChangedType)
+        /// <param name="action">The real action that was performed on the <see cref="FastBindingList{T}"/>.</param>
+        public NotifyRangedListChangedEventArgs(NotifyRangedListChangedAction action)
+            : base(ListChangedType.Reset, -1)
         {
+            Action = action;
+
             NewStartingIndex = -1;
             OldStartingIndex = -1;
         }
@@ -31,18 +33,25 @@ namespace Catel.Collections
         /// <summary>
         /// Initializes a new instance of the <see cref="NotifyRangedListChangedEventArgs"/> class.
         /// </summary>
-        /// <param name="listChangedType">Type of change.</param>
+        /// <param name="action">The real action that was performed on the <see cref="FastBindingList{T}"/>.</param>
         /// <param name="changedItems">The changed items.</param>
         /// <param name="indices">The indices.</param>
-        public NotifyRangedListChangedEventArgs(ListChangedType listChangedType, IList changedItems, IList<int> indices)
-            : base(listChangedType, -1)
+        public NotifyRangedListChangedEventArgs(NotifyRangedListChangedAction action, IList changedItems, IList<int> indices)
+            : base(ListChangedType.Reset, -1)
         {
+            Action = action;
+
             NewItems = changedItems;
             NewStartingIndex = (indices != null && indices.Count != 0) ? indices[0] : -1;
             OldStartingIndex = -1;
 
             Indices = indices;
         }
+
+        /// <summary>
+        /// Gets the real action that was performed on the <see cref="FastBindingList{T}"/>.
+        /// </summary>
+        public NotifyRangedListChangedAction Action { get; private set; }
 
         /// <summary>
         /// Gets the new items.

--- a/src/Catel.MVVM/Catel.MVVM.Shared/Collections/FastBindingList.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/Collections/FastBindingList.cs
@@ -409,14 +409,14 @@ namespace Catel.Collections
                 {
                     if (_suspensionContext.NewItems.Count != 0)
                     {
-                        eventArgs = new NotifyRangedListChangedEventArgs(ListChangedType.ItemAdded, _suspensionContext.NewItems, _suspensionContext.NewItemIndices);
+                        eventArgs = new NotifyRangedListChangedEventArgs(ListChangedType.Reset, _suspensionContext.NewItems, _suspensionContext.NewItemIndices);
                     }
                 }
                 else if (_suspensionContext != null && _suspensionContext.Mode == SuspensionMode.Removing)
                 {
                     if (_suspensionContext.OldItems.Count != 0)
                     {
-                        eventArgs = new NotifyRangedListChangedEventArgs(ListChangedType.ItemDeleted, _suspensionContext.OldItems, _suspensionContext.OldItemIndices);
+                        eventArgs = new NotifyRangedListChangedEventArgs(ListChangedType.Reset, _suspensionContext.OldItems, _suspensionContext.OldItemIndices);
                     }
                 }
                 else

--- a/src/Catel.MVVM/Catel.MVVM.Shared/Collections/FastBindingList.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/Collections/FastBindingList.cs
@@ -409,14 +409,14 @@ namespace Catel.Collections
                 {
                     if (_suspensionContext.NewItems.Count != 0)
                     {
-                        eventArgs = new NotifyRangedListChangedEventArgs(ListChangedType.Reset, _suspensionContext.NewItems, _suspensionContext.NewItemIndices);
+                        eventArgs = new NotifyRangedListChangedEventArgs(NotifyRangedListChangedAction.Add, _suspensionContext.NewItems, _suspensionContext.NewItemIndices);
                     }
                 }
                 else if (_suspensionContext != null && _suspensionContext.Mode == SuspensionMode.Removing)
                 {
                     if (_suspensionContext.OldItems.Count != 0)
                     {
-                        eventArgs = new NotifyRangedListChangedEventArgs(ListChangedType.Reset, _suspensionContext.OldItems, _suspensionContext.OldItemIndices);
+                        eventArgs = new NotifyRangedListChangedEventArgs(NotifyRangedListChangedAction.Remove, _suspensionContext.OldItems, _suspensionContext.OldItemIndices);
                     }
                 }
                 else

--- a/src/Catel.Test/Catel.Test.Shared/Collections/FastBindingListFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Collections/FastBindingListFacts.cs
@@ -243,7 +243,7 @@ namespace Catel.Test.Collections
                 token.Dispose();
 
                 Assert.AreEqual(1, counter);
-                Assert.AreEqual(ListChangedType.ItemAdded, eventArgs.ListChangedType);
+                Assert.AreEqual(ListChangedType.Reset, eventArgs.ListChangedType);
                 CollectionAssert.AreEqual(eventArgs.NewItems, new[] { 1, 2, 3, 4, 5 });
             }
         }
@@ -503,7 +503,7 @@ namespace Catel.Test.Collections
                 }
 
                 Assert.AreEqual(1, counter);
-                Assert.AreEqual(ListChangedType.ItemAdded, eventArgs.ListChangedType);
+                Assert.AreEqual(ListChangedType.Reset, eventArgs.ListChangedType);
                 CollectionAssert.AreEqual(eventArgs.NewItems, new[] { 1, 2, 3, 4, 5 });
             }
 
@@ -537,7 +537,7 @@ namespace Catel.Test.Collections
                 firstToken.Dispose();
                 Assert.AreEqual(1, counter);
                 // ReSharper disable PossibleNullReferenceException
-                Assert.AreEqual(ListChangedType.ItemAdded, eventArgs.ListChangedType);
+                Assert.AreEqual(ListChangedType.Reset, eventArgs.ListChangedType);
                 CollectionAssert.AreEqual(eventArgs.NewItems, new[] { 1, 2, 3, 4, 5 });
                 // ReSharper restore PossibleNullReferenceException
             }
@@ -573,7 +573,7 @@ namespace Catel.Test.Collections
                 firstToken.Dispose();
                 Assert.AreEqual(1, counter);
                 // ReSharper disable PossibleNullReferenceException
-                Assert.AreEqual(ListChangedType.ItemAdded, eventArgs.ListChangedType);
+                Assert.AreEqual(ListChangedType.Reset, eventArgs.ListChangedType);
                 CollectionAssert.AreEqual(eventArgs.NewItems, new[] { 1, 2, 3, 4, 5 });
                 // ReSharper restore PossibleNullReferenceException
             }
@@ -602,7 +602,7 @@ namespace Catel.Test.Collections
                 }
 
                 Assert.AreEqual(1, counter);
-                Assert.AreEqual(ListChangedType.ItemDeleted, eventArgs.ListChangedType);
+                Assert.AreEqual(ListChangedType.Reset, eventArgs.ListChangedType);
                 CollectionAssert.AreEqual(eventArgs.NewItems, new[] { 1, 2, 3, 4, 5 });
             }
 

--- a/src/Catel.Test/Catel.Test.Shared/Collections/FastBindingListFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Collections/FastBindingListFacts.cs
@@ -244,6 +244,7 @@ namespace Catel.Test.Collections
 
                 Assert.AreEqual(1, counter);
                 Assert.AreEqual(ListChangedType.Reset, eventArgs.ListChangedType);
+                Assert.AreEqual(NotifyRangedListChangedAction.Add, eventArgs.Action);
                 CollectionAssert.AreEqual(eventArgs.NewItems, new[] { 1, 2, 3, 4, 5 });
             }
         }
@@ -504,6 +505,7 @@ namespace Catel.Test.Collections
 
                 Assert.AreEqual(1, counter);
                 Assert.AreEqual(ListChangedType.Reset, eventArgs.ListChangedType);
+                Assert.AreEqual(NotifyRangedListChangedAction.Add, eventArgs.Action);
                 CollectionAssert.AreEqual(eventArgs.NewItems, new[] { 1, 2, 3, 4, 5 });
             }
 
@@ -538,6 +540,7 @@ namespace Catel.Test.Collections
                 Assert.AreEqual(1, counter);
                 // ReSharper disable PossibleNullReferenceException
                 Assert.AreEqual(ListChangedType.Reset, eventArgs.ListChangedType);
+                Assert.AreEqual(NotifyRangedListChangedAction.Add, eventArgs.Action);
                 CollectionAssert.AreEqual(eventArgs.NewItems, new[] { 1, 2, 3, 4, 5 });
                 // ReSharper restore PossibleNullReferenceException
             }
@@ -574,6 +577,7 @@ namespace Catel.Test.Collections
                 Assert.AreEqual(1, counter);
                 // ReSharper disable PossibleNullReferenceException
                 Assert.AreEqual(ListChangedType.Reset, eventArgs.ListChangedType);
+                Assert.AreEqual(NotifyRangedListChangedAction.Add, eventArgs.Action);
                 CollectionAssert.AreEqual(eventArgs.NewItems, new[] { 1, 2, 3, 4, 5 });
                 // ReSharper restore PossibleNullReferenceException
             }
@@ -603,6 +607,7 @@ namespace Catel.Test.Collections
 
                 Assert.AreEqual(1, counter);
                 Assert.AreEqual(ListChangedType.Reset, eventArgs.ListChangedType);
+                Assert.AreEqual(NotifyRangedListChangedAction.Remove, eventArgs.Action);
                 CollectionAssert.AreEqual(eventArgs.NewItems, new[] { 1, 2, 3, 4, 5 });
             }
 


### PR DESCRIPTION
ListChangedEventArgs does not support range adding or removing. We can only notify one item add, change or remove. That's why we need to change ListChangedType to Reset and NewIndex to -1 when using NotifyRangedListChangedEventArgs.