### PR TITLE
CTL-875 AddItems method of FastObservableCollection throws "Range actions not supported." exception

### DIFF
--- a/src/Catel.MVVM/Catel.MVVM.Shared/Collections/FastObservableCollection.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/Collections/FastObservableCollection.cs
@@ -124,15 +124,31 @@ namespace Catel.Collections
         #region Methods
         /// <summary>
         /// Inserts the elements of the specified collection at the specified index.
+        /// <para />
+        /// This method will raise a change notification at the end.
         /// </summary>
         /// <param name="collection">The collection.</param>
         /// <param name="index">The start index.</param>
         /// <exception cref="ArgumentNullException">The <paramref name="collection"/> is <c>null</c>.</exception>
         public virtual void InsertItems(IEnumerable<T> collection, int index)
         {
+            InsertItems(collection, index, SuspensionMode.None);
+        }
+
+        /// <summary>
+        /// Inserts the elements of the specified collection at the specified index.
+        /// <para />
+        /// This method will raise a change notification at the end.
+        /// </summary>
+        /// <param name="collection">The collection.</param>
+        /// <param name="index">The start index.</param>
+        /// <param name="mode">The suspension mode.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="collection"/> is <c>null</c>.</exception>
+        public virtual void InsertItems(IEnumerable<T> collection, int index, SuspensionMode mode)
+        {
             Argument.IsNotNull("collection", collection);
 
-            using (SuspendChangeNotifications(SuspensionMode.Adding))
+            using (SuspendChangeNotifications(mode))
             {
                 foreach (var item in collection)
                 {
@@ -143,15 +159,31 @@ namespace Catel.Collections
 
         /// <summary>
         /// Inserts the elements of the specified collection at the specified index.
+        /// <para />
+        /// This method will raise a change notification at the end.
         /// </summary>
         /// <param name="collection">The collection.</param>
         /// <param name="index">The start index.</param>
         /// <exception cref="ArgumentNullException">The <paramref name="collection"/> is <c>null</c>.</exception>
         public virtual void InsertItems(IEnumerable collection, int index)
         {
+            InsertItems(collection, index, SuspensionMode.None);
+        }
+
+        /// <summary>
+        /// Inserts the elements of the specified collection at the specified index.
+        /// <para />
+        /// This method will raise a change notification at the end.
+        /// </summary>
+        /// <param name="collection">The collection.</param>
+        /// <param name="index">The start index.</param>
+        /// <param name="mode">The suspension mode.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="collection"/> is <c>null</c>.</exception>
+        public virtual void InsertItems(IEnumerable collection, int index, SuspensionMode mode)
+        {
             Argument.IsNotNull("collection", collection);
 
-            using (SuspendChangeNotifications(SuspensionMode.Adding))
+            using (SuspendChangeNotifications(mode))
             {
                 foreach (var item in collection)
                 {
@@ -184,9 +216,22 @@ namespace Catel.Collections
         /// <exception cref="ArgumentNullException">The <paramref name="collection"/> is <c>null</c>.</exception>
         public void AddItems(IEnumerable<T> collection)
         {
+            AddItems(collection, SuspensionMode.None);
+        }
+
+        /// <summary>
+        /// Adds the specified items to the collection without causing a change notification for all items.
+        /// <para />
+        /// This method will raise a change notification at the end.
+        /// </summary>
+        /// <param name="collection">The collection.</param>
+        /// <param name="mode">The suspension mode.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="collection"/> is <c>null</c>.</exception>
+        public void AddItems(IEnumerable<T> collection, SuspensionMode mode)
+        {
             Argument.IsNotNull("collection", collection);
 
-            using (SuspendChangeNotifications(SuspensionMode.Adding))
+            using (SuspendChangeNotifications(mode))
             {
                 foreach (var item in collection)
                 {
@@ -204,9 +249,22 @@ namespace Catel.Collections
         /// <exception cref="ArgumentNullException">The <paramref name="collection"/> is <c>null</c>.</exception>
         public void AddItems(IEnumerable collection)
         {
+            AddItems(collection, SuspensionMode.None);
+        }
+
+        /// <summary>
+        /// Adds the specified items to the collection without causing a change notification for all items.
+        /// <para />
+        /// This method will raise a change notification at the end.
+        /// </summary>
+        /// <param name="collection">The collection.</param>
+        /// <param name="mode">The suspension mode.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="collection"/> is <c>null</c>.</exception>
+        public void AddItems(IEnumerable collection, SuspensionMode mode)
+        {
             Argument.IsNotNull("collection", collection);
 
-            using (SuspendChangeNotifications(SuspensionMode.Adding))
+            using (SuspendChangeNotifications(mode))
             {
                 foreach (var item in collection)
                 {
@@ -224,9 +282,22 @@ namespace Catel.Collections
         /// <exception cref="ArgumentNullException">The <paramref name="collection"/> is <c>null</c>.</exception>
         public void RemoveItems(IEnumerable<T> collection)
         {
+            RemoveItems(collection, SuspensionMode.None);
+        }
+
+        /// <summary>
+        /// Removes the specified items from the collection without causing a change notification for all items.
+        /// <para />
+        /// This method will raise a change notification at the end.
+        /// </summary>
+        /// <param name="collection">The collection.</param>
+        /// <param name="mode">The suspension mode.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="collection"/> is <c>null</c>.</exception>
+        public void RemoveItems(IEnumerable<T> collection, SuspensionMode mode)
+        {
             Argument.IsNotNull("collection", collection);
 
-            using (SuspendChangeNotifications(SuspensionMode.Removing))
+            using (SuspendChangeNotifications(mode))
             {
                 foreach (var item in collection)
                 {
@@ -244,9 +315,22 @@ namespace Catel.Collections
         /// <exception cref="ArgumentNullException">The <paramref name="collection"/> is <c>null</c>.</exception>
         public void RemoveItems(IEnumerable collection)
         {
+            RemoveItems(collection, SuspensionMode.None);
+        }
+
+        /// <summary>
+        /// Removes the specified items from the collection without causing a change notification for all items.
+        /// <para />
+        /// This method will raise a change notification at the end.
+        /// </summary>
+        /// <param name="collection">The collection.</param>
+        /// <param name="mode">The suspension mode.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="collection"/> is <c>null</c>.</exception>
+        public void RemoveItems(IEnumerable collection, SuspensionMode mode)
+        {
             Argument.IsNotNull("collection", collection);
 
-            using (SuspendChangeNotifications(SuspensionMode.Removing))
+            using (SuspendChangeNotifications(mode))
             {
                 foreach (var item in collection)
                 {
@@ -552,6 +636,6 @@ namespace Catel.Collections
 
             return eventArgs;
         }
-#endregion
+        #endregion
     }
 }

--- a/src/Catel.Test/Catel.Test.Shared/Collections/FastBindingListFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Collections/FastBindingListFacts.cs
@@ -86,6 +86,7 @@ namespace Catel.Test.Collections
             public void ThrowsArgumentNullExceptionForNullCollection()
             {
                 var fastCollection = new FastBindingList<int>();
+                fastCollection.AutomaticallyDispatchChangeNotifications = false;
                 ExceptionTester.CallMethodAndExpectException<ArgumentNullException>(() => fastCollection.AddItems(null));
             }
 
@@ -105,14 +106,36 @@ namespace Catel.Test.Collections
                 fastCollection.AddItems(new ArrayList(new[] { 1, 2, 3, 4, 5 }));
 
                 Assert.AreEqual(2, counter);
+            }
+        }
+
+        [TestFixture]
+        public class TheInsertRangeMethod
+        {
+            [TestCase]
+            public void ThrowsArgumentNullExceptionForNullCollection()
+            {
+                var fastCollection = new FastBindingList<int>();
+                fastCollection.AutomaticallyDispatchChangeNotifications = false;
+                ExceptionTester.CallMethodAndExpectException<ArgumentNullException>(() => fastCollection.InsertItems(null, 0));
+            }
+
+            [TestCase]
+            public void RaisesSingleEventWhileAddingRange()
+            {
+                int counter = 0;
+
+                var fastCollection = new FastBindingList<int>();
+                fastCollection.AutomaticallyDispatchChangeNotifications = false;
+                fastCollection.ListChanged += (sender, e) => counter++;
 
                 fastCollection.InsertItems(new[] { 1, 2, 3, 4, 5 }, 0);
 
-                Assert.AreEqual(3, counter);
+                Assert.AreEqual(1, counter);
 
                 fastCollection.InsertItems(new ArrayList(new[] { 1, 2, 3, 4, 5 }), 0);
 
-                Assert.AreEqual(4, counter);
+                Assert.AreEqual(2, counter);
             }
         }
 
@@ -123,6 +146,7 @@ namespace Catel.Test.Collections
             public void ThrowsArgumentNullExceptionForNullCollection()
             {
                 var fastCollection = new FastBindingList<int>();
+                fastCollection.AutomaticallyDispatchChangeNotifications = false;
                 ExceptionTester.CallMethodAndExpectException<ArgumentNullException>(() => fastCollection.RemoveItems(null));
             }
 

--- a/src/Catel.Test/Catel.Test.Shared/Collections/FastObservableCollectionFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Collections/FastObservableCollectionFacts.cs
@@ -90,7 +90,17 @@ namespace Catel.Test.Collections
             public void ThrowsArgumentNullExceptionForNullCollection()
             {
                 var fastCollection = new FastObservableCollection<int>();
-                ExceptionTester.CallMethodAndExpectException<ArgumentNullException>(() => ((ICollection<int>)fastCollection).AddRange(null));
+                fastCollection.AutomaticallyDispatchChangeNotifications = false;
+                ExceptionTester.CallMethodAndExpectException<ArgumentNullException>(() => fastCollection.AddItems(null));
+                ExceptionTester.CallMethodAndExpectException<ArgumentNullException>(() => fastCollection.AddItems(null, SuspensionMode.Adding));
+            }
+
+            [TestCase]
+            public void ThrowsInvalidOperationExceptionForInvalidSuspensionMode()
+            {
+                var fastCollection = new FastObservableCollection<int>();
+                fastCollection.AutomaticallyDispatchChangeNotifications = false;
+                ExceptionTester.CallMethodAndExpectException<InvalidOperationException>(() => fastCollection.AddItems(new[] { 1, 2, 3, 4, 5 }, SuspensionMode.Removing));
             }
 
             [TestCase]
@@ -106,17 +116,148 @@ namespace Catel.Test.Collections
 
                 Assert.AreEqual(1, counter);
 
-                fastCollection.AddItems(new ArrayList(new[] { 1, 2, 3, 4, 5 }));
+                fastCollection.AddItems(new[] { 1, 2, 3, 4, 5 }, SuspensionMode.Adding);
 
                 Assert.AreEqual(2, counter);
 
-                fastCollection.InsertItems(new[] { 1, 2, 3, 4, 5 }, 0);
+                fastCollection.AddItems(new ArrayList(new[] { 1, 2, 3, 4, 5 }));
 
                 Assert.AreEqual(3, counter);
 
-                fastCollection.InsertItems(new ArrayList(new[] { 1, 2, 3, 4, 5 }), 0);
+                fastCollection.AddItems(new ArrayList(new[] { 1, 2, 3, 4, 5 }), SuspensionMode.Adding);
 
                 Assert.AreEqual(4, counter);
+            }
+
+            [TestCase]
+            public void RaisesSingleAddEventWhileAddingRangeInSuspensionModeAdding()
+            {
+                var eventArgs = default(NotifyCollectionChangedEventArgs);
+
+                var fastCollection = new FastObservableCollection<int>();
+                fastCollection.AutomaticallyDispatchChangeNotifications = false;
+                fastCollection.CollectionChanged += (sender, e) => eventArgs = e;
+
+                fastCollection.AddItems(new[] { 1, 2, 3, 4, 5 }, SuspensionMode.Adding);
+
+                Assert.AreEqual(NotifyCollectionChangedAction.Add, eventArgs.Action);
+            }
+
+            [TestCase]
+            public void RaisesSingleResetEventWhileAddingRangeInSuspensionModeNone()
+            {
+                var eventArgs = default(NotifyCollectionChangedEventArgs);
+
+                var fastCollection = new FastObservableCollection<int>();
+                fastCollection.AutomaticallyDispatchChangeNotifications = false;
+                fastCollection.CollectionChanged += (sender, e) => eventArgs = e;
+
+                fastCollection.AddItems(new[] { 1, 2, 3, 4, 5 }, SuspensionMode.None);
+
+                Assert.AreEqual(NotifyCollectionChangedAction.Reset, eventArgs.Action);
+            }
+
+            [TestCase]
+            public void RaisesSingleResetEventWhileAddingRangeWithoutSuspensionMode()
+            {
+                var eventArgs = default(NotifyCollectionChangedEventArgs);
+
+                var fastCollection = new FastObservableCollection<int>();
+                fastCollection.AutomaticallyDispatchChangeNotifications = false;
+                fastCollection.CollectionChanged += (sender, e) => eventArgs = e;
+
+                fastCollection.AddItems(new[] { 1, 2, 3, 4, 5 });
+
+                Assert.AreEqual(NotifyCollectionChangedAction.Reset, eventArgs.Action);
+            }
+        }
+
+        [TestFixture]
+        public class TheInsertRangeMethod
+        {
+            [TestCase]
+            public void ThrowsArgumentNullExceptionForNullCollection()
+            {
+                var fastCollection = new FastObservableCollection<int>();
+                fastCollection.AutomaticallyDispatchChangeNotifications = false;
+                ExceptionTester.CallMethodAndExpectException<ArgumentNullException>(() => fastCollection.InsertItems(null, 0));
+                ExceptionTester.CallMethodAndExpectException<ArgumentNullException>(() => fastCollection.InsertItems(null, 0, SuspensionMode.Adding));
+            }
+
+            [TestCase]
+            public void ThrowsInvalidOperationExceptionForInvalidSuspensionMode()
+            {
+                var fastCollection = new FastObservableCollection<int>();
+                fastCollection.AutomaticallyDispatchChangeNotifications = false;
+                ExceptionTester.CallMethodAndExpectException<InvalidOperationException>(() => fastCollection.InsertItems(new[] { 1, 2, 3, 4, 5 }, 0, SuspensionMode.Removing));
+            }
+
+            [TestCase]
+            public void RaisesSingleEventWhileInsertingRange()
+            {
+                int counter = 0;
+
+                var fastCollection = new FastObservableCollection<int>();
+                fastCollection.AutomaticallyDispatchChangeNotifications = false;
+                fastCollection.CollectionChanged += (sender, e) => counter++;
+
+                fastCollection.InsertItems(new[] { 1, 2, 3, 4, 5 }, 0);
+
+                Assert.AreEqual(1, counter);
+
+                fastCollection.InsertItems(new[] { 1, 2, 3, 4, 5 }, 0, SuspensionMode.Adding);
+
+                Assert.AreEqual(2, counter);
+
+                fastCollection.InsertItems(new ArrayList(new[] { 1, 2, 3, 4, 5 }), 0);
+
+                Assert.AreEqual(3, counter);
+
+                fastCollection.InsertItems(new ArrayList(new[] { 1, 2, 3, 4, 5 }), 0, SuspensionMode.Adding);
+
+                Assert.AreEqual(4, counter);
+            }
+
+            [TestCase]
+            public void RaisesSingleAddEventWhileInsertingRangeInSuspensionModeAdding()
+            {
+                var eventArgs = default(NotifyCollectionChangedEventArgs);
+
+                var fastCollection = new FastObservableCollection<int>();
+                fastCollection.AutomaticallyDispatchChangeNotifications = false;
+                fastCollection.CollectionChanged += (sender, e) => eventArgs = e;
+
+                fastCollection.InsertItems(new[] { 1, 2, 3, 4, 5 }, 0, SuspensionMode.Adding);
+
+                Assert.AreEqual(NotifyCollectionChangedAction.Add, eventArgs.Action);
+            }
+
+            [TestCase]
+            public void RaisesSingleResetEventWhileInsertingRangeInSuspensionModeNone()
+            {
+                var eventArgs = default(NotifyCollectionChangedEventArgs);
+
+                var fastCollection = new FastObservableCollection<int>();
+                fastCollection.AutomaticallyDispatchChangeNotifications = false;
+                fastCollection.CollectionChanged += (sender, e) => eventArgs = e;
+
+                fastCollection.InsertItems(new[] { 1, 2, 3, 4, 5 }, 0, SuspensionMode.None);
+
+                Assert.AreEqual(NotifyCollectionChangedAction.Reset, eventArgs.Action);
+            }
+
+            [TestCase]
+            public void RaisesSingleResetEventWhileInsertingRangeWithoutSuspensionMode()
+            {
+                var eventArgs = default(NotifyCollectionChangedEventArgs);
+
+                var fastCollection = new FastObservableCollection<int>();
+                fastCollection.AutomaticallyDispatchChangeNotifications = false;
+                fastCollection.CollectionChanged += (sender, e) => eventArgs = e;
+
+                fastCollection.InsertItems(new[] { 1, 2, 3, 4, 5 }, 0);
+
+                Assert.AreEqual(NotifyCollectionChangedAction.Reset, eventArgs.Action);
             }
         }
 
@@ -127,7 +268,17 @@ namespace Catel.Test.Collections
             public void ThrowsArgumentNullExceptionForNullCollection()
             {
                 var fastCollection = new FastObservableCollection<int>();
+                fastCollection.AutomaticallyDispatchChangeNotifications = false;
                 ExceptionTester.CallMethodAndExpectException<ArgumentNullException>(() => fastCollection.RemoveItems(null));
+                ExceptionTester.CallMethodAndExpectException<ArgumentNullException>(() => fastCollection.RemoveItems(null, SuspensionMode.Removing));
+            }
+
+            [TestCase]
+            public void ThrowsInvalidOperationExceptionForInvalidSuspensionMode()
+            {
+                var fastCollection = new FastObservableCollection<int>(new[] { 1, 2, 3, 4, 5 });
+                fastCollection.AutomaticallyDispatchChangeNotifications = false;
+                ExceptionTester.CallMethodAndExpectException<InvalidOperationException>(() => fastCollection.RemoveItems(new[] { 1, 2, 3, 4, 5 }, SuspensionMode.Adding));
             }
 
             [TestCase]
@@ -135,7 +286,7 @@ namespace Catel.Test.Collections
             {
                 int counter = 0;
 
-                var fastCollection = new FastObservableCollection<int>(new [] { 1, 2, 3, 4, 5, 1, 2, 3, 4, 5 });
+                var fastCollection = new FastObservableCollection<int>(new[] { 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5 });
                 fastCollection.AutomaticallyDispatchChangeNotifications = false;
                 fastCollection.CollectionChanged += (sender, e) => counter++;
 
@@ -143,9 +294,59 @@ namespace Catel.Test.Collections
 
                 Assert.AreEqual(1, counter);
 
-                fastCollection.RemoveItems(new ArrayList(new[] { 1, 2, 3, 4, 5 }));
+                fastCollection.RemoveItems(new[] { 1, 2, 3, 4, 5 }, SuspensionMode.Removing);
 
                 Assert.AreEqual(2, counter);
+
+                fastCollection.RemoveItems(new ArrayList(new[] { 1, 2, 3, 4, 5 }));
+
+                Assert.AreEqual(3, counter);
+
+                fastCollection.RemoveItems(new ArrayList(new[] { 1, 2, 3, 4, 5 }), SuspensionMode.Removing);
+
+                Assert.AreEqual(4, counter);
+            }
+
+            [TestCase]
+            public void RaisesSingleRemoveEventWhileRemovingRangeInSuspensionModeRemoving()
+            {
+                var eventArgs = default(NotifyCollectionChangedEventArgs);
+
+                var fastCollection = new FastObservableCollection<int>(new[] { 1, 2, 3, 4, 5 });
+                fastCollection.AutomaticallyDispatchChangeNotifications = false;
+                fastCollection.CollectionChanged += (sender, e) => eventArgs = e;
+
+                fastCollection.RemoveItems(new[] { 1, 2, 3, 4, 5 }, SuspensionMode.Removing);
+
+                Assert.AreEqual(NotifyCollectionChangedAction.Remove, eventArgs.Action);
+            }
+
+            [TestCase]
+            public void RaisesSingleResetEventWhileRemovingRangeInSuspensionModeNone()
+            {
+                var eventArgs = default(NotifyCollectionChangedEventArgs);
+
+                var fastCollection = new FastObservableCollection<int>(new[] { 1, 2, 3, 4, 5 });
+                fastCollection.AutomaticallyDispatchChangeNotifications = false;
+                fastCollection.CollectionChanged += (sender, e) => eventArgs = e;
+
+                fastCollection.RemoveItems(new[] { 1, 2, 3, 4, 5 }, SuspensionMode.None);
+
+                Assert.AreEqual(NotifyCollectionChangedAction.Reset, eventArgs.Action);
+            }
+
+            [TestCase]
+            public void RaisesSingleRemoveEventWhileRemovingRangeWithoutSuspensionMode()
+            {
+                var eventArgs = default(NotifyCollectionChangedEventArgs);
+
+                var fastCollection = new FastObservableCollection<int>(new[] { 1, 2, 3, 4, 5 });
+                fastCollection.AutomaticallyDispatchChangeNotifications = false;
+                fastCollection.CollectionChanged += (sender, e) => eventArgs = e;
+
+                fastCollection.RemoveItems(new[] { 1, 2, 3, 4, 5 });
+
+                Assert.AreEqual(NotifyCollectionChangedAction.Reset, eventArgs.Action);
             }
         }
 
@@ -207,7 +408,7 @@ namespace Catel.Test.Collections
             [TestCase]
             public void ResetWithoutSuspendChangeNotifications()
             {
-                var collectionChanged= false;
+                var collectionChanged = false;
                 var fastCollection = new FastObservableCollection<int>();
                 fastCollection.AutomaticallyDispatchChangeNotifications = false;
                 fastCollection.CollectionChanged += (sender, e) =>


### PR DESCRIPTION
I also did some small fixes:

1) Fixed comments for InsertItems,
2) Splited TheAddRangeMethod tests to TheAddRangeMethod and TheInsertRangeMethod test,
3) Fixed ThrowsArgumentNullExceptionForNullCollection in TheAddRangeMethod which was testing AddRange method instead of AddItems method.