### PR TITLE
resourceName field is now accessable from outside via property

### DIFF
--- a/src/Catel.Core/Catel.Core.Shared/ComponentModel/DisplayNameAttribute.cs
+++ b/src/Catel.Core/Catel.Core.Shared/ComponentModel/DisplayNameAttribute.cs
@@ -93,7 +93,7 @@ namespace Catel.ComponentModel
         {
             get
             {
-                return this._resourceName;
+                return _resourceName;
             }
         }
     }

--- a/src/Catel.Core/Catel.Core.Shared/ComponentModel/DisplayNameAttribute.cs
+++ b/src/Catel.Core/Catel.Core.Shared/ComponentModel/DisplayNameAttribute.cs
@@ -84,5 +84,17 @@ namespace Catel.ComponentModel
                 return displayName;
             }
         }
+
+        /// <summary>
+        /// Gets the resource name.
+        /// </summary>
+        /// <value>The resource name.</value>
+        public string ResourceName
+        {
+            get
+            {
+                return this._resourceName;
+            }
+        }
     }
 }


### PR DESCRIPTION
Sometimes it is necessary to get a language string for other cultures (instead of the current culture).