### PR TITLE
CTL-918 Improve code snippets so they support UWP

### DIFF
--- a/snippets/C#/model.snippet
+++ b/snippets/C#/model.snippet
@@ -25,7 +25,7 @@
 /// </summary>
 #if NETFX_CORE
 [DataContract]
-#elif !SILVERLIGHT
+#else
 [Serializable]
 #endif
 public class $name$ : ModelBase
@@ -39,7 +39,7 @@ public class $name$ : ModelBase
     /// </summary>
     public $name$() { }
 
-#if !SILVERLIGHT	&& !NETFX_CORE
+#if !NETFX_CORE
     /// <summary>
     /// Initializes a new object based on <see cref="SerializationInfo"/>.
     /// </summary>

--- a/snippets/C#/model.snippet
+++ b/snippets/C#/model.snippet
@@ -23,7 +23,9 @@
 /// $name$ model which fully supports serialization, property changed notifications,
 /// backwards compatibility and error checking.
 /// </summary>
-#if !SILVERLIGHT
+#if NETFX_CORE
+[DataContract]
+#elif !SILVERLIGHT
 [Serializable]
 #endif
 public class $name$ : ModelBase
@@ -37,7 +39,7 @@ public class $name$ : ModelBase
     /// </summary>
     public $name$() { }
 
-#if !SILVERLIGHT	
+#if !SILVERLIGHT	&& !NETFX_CORE
     /// <summary>
     /// Initializes a new object based on <see cref="SerializationInfo"/>.
     /// </summary>

--- a/snippets/C#/modelprop.snippet
+++ b/snippets/C#/modelprop.snippet
@@ -37,6 +37,11 @@
                 <![CDATA[/// <summary>
 /// $description$.
 /// </summary>
+#if NETFX_CORE
+[DataMember]
+// TODO: use the following line instead of the one above, if you want to ignore the property for (de)serialization
+//[IgnoreDataMember]
+#endif
 public $type$ $name$
 {
 	get { return GetValue<$type$>($name$Property); }

--- a/snippets/C#/modelpropchanged.snippet
+++ b/snippets/C#/modelpropchanged.snippet
@@ -43,6 +43,11 @@
                 <![CDATA[/// <summary>
 /// $description$.
 /// </summary>
+#if NETFX_CORE
+[DataMember]
+// TODO: use the following line instead of the one above, if you want to ignore the property for (de)serialization
+//[IgnoreDataMember]
+#endif
 public $type$ $name$
 {
 	get { return GetValue<$type$>($name$Property); }


### PR DESCRIPTION
I've added missing attributes to support model\* snippets in UWP.

This PR should probably remain open, so that I can add more commits whenever I come across similar issues while working on my UWP app. Let me know your thoughts!
