### PR TITLE
CTL-923 Refactor Loggers to Bind to Strings Instead of Types

### DIFF
--- a/src/Catel.Core/Catel.Core.Shared/Argument.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Argument.cs
@@ -27,7 +27,8 @@ namespace Catel
         /// <summary>
         /// The <see cref="ILog">log</see> object.
         /// </summary>
-        private static readonly ILog Log = LogManager.GetCurrentClassLogger();
+        private static readonly ILog Log = LogManager.GetCatelLogger(typeof(Argument), true);
+
         #endregion
 
         #region Methods

--- a/src/Catel.Core/Catel.Core.Shared/Catel.Core.Shared.projitems
+++ b/src/Catel.Core/Catel.Core.Shared/Catel.Core.Shared.projitems
@@ -234,6 +234,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)IO\Extensions\StreamExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IO\Path.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Logging\BatchLogListenerBase.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Logging\CatelLog.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Logging\Configuration\LoggingConfigurationSection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Logging\Configuration\LogListenerConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Logging\Configuration\LogListenerConfigurationCollection.cs" />
@@ -249,6 +250,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Logging\Formatters\Interfaces\IJsonLogFormatter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Logging\Formatters\JsonLogFormatter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Logging\Interfaces\IBatchLogListener.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Logging\Interfaces\ICatelLog.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Logging\Interfaces\ILog.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Logging\Interfaces\ILogListener.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Logging\Listeners\ConsoleLogListener.cs" />

--- a/src/Catel.Core/Catel.Core.Shared/Logging/CatelLog.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Logging/CatelLog.cs
@@ -1,10 +1,14 @@
-﻿using System;
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CatelLog.cs" company="Catel development team">
+//   Copyright (c) 2016 - 2016 Catel development team. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+using System;
 
 
 namespace Catel.Logging
 {
-    using Interfaces;
-
     /// <summary>
     /// Logging class used internally for Catel. 
     /// </summary>
@@ -16,7 +20,8 @@ namespace Catel.Logging
         /// <param name="name">The name of this logger.</param>
         /// <param name="alwaysLog">Flag indicating whether this log should always write logging statements regardless of log filter settings.</param>
         /// <exception cref="ArgumentException">If <paramref name="name"/> is null or a whitespace.</exception>
-        public CatelLog(string name, bool alwaysLog) : base(name, null)
+        public CatelLog(string name, bool alwaysLog)
+            : base(name, null)
         {
             AlwaysLog = alwaysLog;
         }

--- a/src/Catel.Core/Catel.Core.Shared/Logging/CatelLog.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Logging/CatelLog.cs
@@ -1,0 +1,50 @@
+﻿using System;
+
+
+namespace Catel.Logging
+{
+    using Interfaces;
+
+    /// <summary>
+    /// Logging class used internally for Catel. 
+    /// </summary>
+    internal class CatelLog : Log, ICatelLog
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CatelLog"/> class.
+        /// </summary>
+        /// <param name="name">The name of this logger.</param>
+        /// <param name="alwaysLog">Flag indicating whether this log should always write logging statements regardless of log filter settings.</param>
+        /// <exception cref="ArgumentException">If <paramref name="name"/> is null or a whitespace.</exception>
+        public CatelLog(string name, bool alwaysLog) : base(name, null)
+        {
+            AlwaysLog = alwaysLog;
+        }
+
+        #region Implementation of ICatelLog
+
+        /// <summary>
+        /// Gets a value indicating whether this log should always write logging statements regardless of log filter settings.
+        /// </summary>
+        public bool AlwaysLog { get; }
+
+        #endregion
+
+        #region Overrides of Log
+
+        /// <summary>
+        /// Gets a value indicating whether this logger is a Catel logger.
+        /// <para />
+        /// This value can be useful to exclude Catel logging for external listeners.
+        /// </summary>
+        /// <value>
+        /// 	<c>true</c> if this instance is a Catel logger; otherwise, <c>false</c>.
+        /// </value>
+        public override bool IsCatelLogging
+        {
+            get { return true; }
+        }
+
+        #endregion
+    }
+}

--- a/src/Catel.Core/Catel.Core.Shared/Logging/Formatters/JsonLogFormatter.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Logging/Formatters/JsonLogFormatter.cs
@@ -12,7 +12,6 @@ namespace Catel.Logging
     using System.Collections.Generic;
     using System.Globalization;
     using System.IO;
-    using System.Reflection;
     using Reflection;
 
     /// <summary>
@@ -107,6 +106,7 @@ namespace Catel.Logging
             var pdelim = string.Empty;
             WriteJsonProperty("ApplicationName", ApplicationName, ref pdelim, textWriter);
             WriteJsonProperty("ApplicationVersion", ApplicationVersion, ref pdelim, textWriter);
+            WriteJsonProperty("Name", log.Name, ref pdelim, textWriter);
             WriteJsonProperty("TargetType", log.TargetType.FullName, ref pdelim, textWriter);
 
             textWriter.Write("}");

--- a/src/Catel.Core/Catel.Core.Shared/Logging/Formatters/JsonLogFormatter.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Logging/Formatters/JsonLogFormatter.cs
@@ -107,7 +107,7 @@ namespace Catel.Logging
             WriteJsonProperty("ApplicationName", ApplicationName, ref pdelim, textWriter);
             WriteJsonProperty("ApplicationVersion", ApplicationVersion, ref pdelim, textWriter);
             WriteJsonProperty("Name", log.Name, ref pdelim, textWriter);
-            WriteJsonProperty("TargetType", log.TargetType.FullName, ref pdelim, textWriter);
+            WriteJsonProperty("TargetType", log.TargetType?.FullName ?? string.Empty, ref pdelim, textWriter);
 
             textWriter.Write("}");
 

--- a/src/Catel.Core/Catel.Core.Shared/Logging/Interfaces/ICatelLog.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Logging/Interfaces/ICatelLog.cs
@@ -4,7 +4,7 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace Catel.Logging.Interfaces
+namespace Catel.Logging
 {
     /// <summary>
     /// Log interface used internally for Catel.

--- a/src/Catel.Core/Catel.Core.Shared/Logging/Interfaces/ICatelLog.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Logging/Interfaces/ICatelLog.cs
@@ -1,0 +1,19 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ICatelLog.cs" company="Catel development team">
+//   Copyright (c) 2016 - 2016 Catel development team. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Catel.Logging.Interfaces
+{
+    /// <summary>
+    /// Log interface used internally for Catel.
+    /// </summary>
+    internal interface ICatelLog : ILog
+    {
+        /// <summary>
+        /// Gets a value indicating whether this log should always write logging statements regardless of log filter settings.
+        /// </summary>
+        bool AlwaysLog { get; }
+    }
+}

--- a/src/Catel.Core/Catel.Core.Shared/Logging/Interfaces/ILog.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Logging/Interfaces/ILog.cs
@@ -15,6 +15,11 @@ namespace Catel.Logging
     {
         #region Properties
         /// <summary>
+        /// Gets the name of the logger.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
         /// Gets the target type of the log. This is the type where the log is created for.
         /// </summary>
         /// <value>The type of the target.</value>

--- a/src/Catel.Core/Catel.Core.Shared/Logging/Listeners/EventLogListener.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Logging/Listeners/EventLogListener.cs
@@ -77,7 +77,7 @@ namespace Catel.Logging
         /// <returns>The formatted log event.</returns>
         protected override string FormatLogEvent(ILog log, string message, LogEvent logEvent, object extraData, LogData logData, DateTime time)
         {
-            var logMessage = string.Format("[{0}] {1}", log.TargetType.FullName, message);
+            var logMessage = string.Format("[{0}] {1}", log.Name, message);
             return logMessage;
         }
 

--- a/src/Catel.Core/Catel.Core.Shared/Logging/Log.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Logging/Log.cs
@@ -24,10 +24,9 @@ namespace Catel.Logging
         /// Initializes a new instance of the <see cref="Log"/> class.
         /// </summary>
         /// <param name="targetType">The type for which this logger is intended.</param>
-        /// <exception cref="ArgumentNullException">If <paramref name="targetType"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="targetType"/> is <c>null</c>.</exception>
         public Log(Type targetType) : this(targetType?.FullName, targetType)
         {
-            Argument.IsNotNull("targetType", targetType);
         }
 
         /// <summary>
@@ -83,7 +82,7 @@ namespace Catel.Logging
         /// <value>
         /// 	<c>true</c> if this instance is a Catel logger; otherwise, <c>false</c>.
         /// </value>
-        public bool IsCatelLogging { get; }
+        public virtual bool IsCatelLogging { get; }
 
         /// <summary>
         /// Gets or sets the size of the indent.

--- a/src/Catel.Core/Catel.Core.Shared/Logging/Log.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Logging/Log.cs
@@ -25,14 +25,9 @@ namespace Catel.Logging
         /// </summary>
         /// <param name="targetType">The type for which this logger is intended.</param>
         /// <exception cref="ArgumentNullException">If <paramref name="targetType"/> is <c>null</c>.</exception>
-        public Log(Type targetType)
+        public Log(Type targetType) : this(targetType?.FullName, targetType)
         {
             Argument.IsNotNull("targetType", targetType);
-
-            Name = targetType.FullName;
-            TargetType = targetType;
-
-            IsCatelLogging = targetType.IsCatelType();
         }
 
         /// <summary>
@@ -40,14 +35,8 @@ namespace Catel.Logging
         /// </summary>
         /// <param name="name">The name of this logger.</param>
         /// <exception cref="ArgumentException">If <paramref name="name"/> is null or a whitespace.</exception>
-        public Log(string name)
+        public Log(string name) : this(name, null)
         {
-            Argument.IsNotNullOrWhitespace("name", name);
-
-            Name = name;
-            TargetType = null;
-
-            IsCatelLogging = false;
         }
 
         /// <summary>
@@ -56,11 +45,9 @@ namespace Catel.Logging
         /// <param name="name">The name of this logger.</param>
         /// <param name="targetType">The type for which this logger is intended.</param>
         /// <exception cref="ArgumentException">If <paramref name="name"/> is null or a whitespace.</exception>
-        /// <exception cref="ArgumentNullException">If <paramref name="targetType"/> is <c>null</c>.</exception>
         public Log(string name, Type targetType)
         {
             Argument.IsNotNullOrWhitespace("name", name);
-            Argument.IsNotNull("targetType", targetType);
 
             Name = name;
             TargetType = targetType;

--- a/src/Catel.Core/Catel.Core.Shared/Logging/Log.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Logging/Log.cs
@@ -25,7 +25,8 @@ namespace Catel.Logging
         /// </summary>
         /// <param name="targetType">The type for which this logger is intended.</param>
         /// <exception cref="ArgumentException">If <paramref name="targetType"/> is <c>null</c>.</exception>
-        public Log(Type targetType) : this(targetType?.FullName, targetType)
+        public Log(Type targetType)
+            : this(targetType?.FullName, targetType)
         {
         }
 
@@ -34,7 +35,8 @@ namespace Catel.Logging
         /// </summary>
         /// <param name="name">The name of this logger.</param>
         /// <exception cref="ArgumentException">If <paramref name="name"/> is null or a whitespace.</exception>
-        public Log(string name) : this(name, null)
+        public Log(string name)
+            : this(name, null)
         {
         }
 

--- a/src/Catel.Core/Catel.Core.Shared/Logging/Log.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Logging/Log.cs
@@ -23,14 +23,47 @@ namespace Catel.Logging
         /// <summary>
         /// Initializes a new instance of the <see cref="Log"/> class.
         /// </summary>
-        /// <param name="targetType">The type for which this log is intented.</param>
-        /// <exception cref="ArgumentNullException">The <paramref name="targetType"/> is <c>null</c>.</exception>
+        /// <param name="targetType">The type for which this logger is intended.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="targetType"/> is <c>null</c>.</exception>
         public Log(Type targetType)
         {
             Argument.IsNotNull("targetType", targetType);
 
+            Name = targetType.FullName;
             TargetType = targetType;
-            Tag = targetType.FullName;
+
+            IsCatelLogging = targetType.IsCatelType();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Log"/> class.
+        /// </summary>
+        /// <param name="name">The name of this logger.</param>
+        /// <exception cref="ArgumentException">If <paramref name="name"/> is null or a whitespace.</exception>
+        public Log(string name)
+        {
+            Argument.IsNotNullOrWhitespace("name", name);
+
+            Name = name;
+            TargetType = null;
+
+            IsCatelLogging = false;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Log"/> class.
+        /// </summary>
+        /// <param name="name">The name of this logger.</param>
+        /// <param name="targetType">The type for which this logger is intended.</param>
+        /// <exception cref="ArgumentException">If <paramref name="name"/> is null or a whitespace.</exception>
+        /// <exception cref="ArgumentNullException">If <paramref name="targetType"/> is <c>null</c>.</exception>
+        public Log(string name, Type targetType)
+        {
+            Argument.IsNotNullOrWhitespace("name", name);
+            Argument.IsNotNull("targetType", targetType);
+
+            Name = name;
+            TargetType = targetType;
 
             IsCatelLogging = targetType.IsCatelType();
         }
@@ -38,10 +71,16 @@ namespace Catel.Logging
 
         #region Properties
         /// <summary>
+        /// Gets the name of the logger.
+        /// </summary>
+        /// <value>The name of the logger.</value>
+        public string Name { get; }
+
+        /// <summary>
         /// Gets the target type of the log. This is the type where the log is created for.
         /// </summary>
         /// <value>The type of the target.</value>
-        public Type TargetType { get; private set; }
+        public Type TargetType { get; }
 
         /// <summary>
         /// Gets or sets the tag.
@@ -57,7 +96,7 @@ namespace Catel.Logging
         /// <value>
         /// 	<c>true</c> if this instance is a Catel logger; otherwise, <c>false</c>.
         /// </value>
-        public bool IsCatelLogging { get; private set; }
+        public bool IsCatelLogging { get; }
 
         /// <summary>
         /// Gets or sets the size of the indent.

--- a/src/Catel.Core/Catel.Core.Shared/Logging/Log.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Logging/Log.cs
@@ -52,7 +52,7 @@ namespace Catel.Logging
             Name = name;
             TargetType = targetType;
 
-            IsCatelLogging = targetType.IsCatelType();
+            IsCatelLogging = targetType?.IsCatelType() ?? false;
         }
         #endregion
 

--- a/src/Catel.Core/Catel.Core.Shared/Logging/LogListenerBase.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Logging/LogListenerBase.cs
@@ -9,7 +9,6 @@ namespace Catel.Logging
 {
     using System;
     using System.Collections.Generic;
-    using Interfaces;
 
     /// <summary>
     /// Abstract base class that implements the <see cref="ILogListener"/> interface.
@@ -21,8 +20,6 @@ namespace Catel.Logging
         /// The log event strings.
         /// </summary>
         protected static readonly Dictionary<LogEvent, string> LogEventStrings;
-
-        private static readonly Type ArgumentType = typeof(Argument);
         #endregion
 
         #region Fields
@@ -165,9 +162,9 @@ namespace Catel.Logging
         /// <param name="time">The time.</param>
         void ILogListener.Write(ILog log, string message, LogEvent logEvent, object extraData, LogData logData, DateTime time)
         {
-            // If the log is a catel log and the AlwaysLog flag is set, log the message.
+            // If the log is a catel log and the AlwaysLog flag is set, skip additional checks and log the message.
             var catelLog = log as ICatelLog;
-            if (!catelLog?.AlwaysLog ?? true)
+            if (catelLog == null || !catelLog.AlwaysLog)
             {
                 if (IgnoreCatelLogging && log.IsCatelLogging)
                 {
@@ -195,9 +192,9 @@ namespace Catel.Logging
         /// <param name="time">The time.</param>
         void ILogListener.Debug(ILog log, string message, object extraData, LogData logData, DateTime time)
         {
-            // If the log is a catel log and the AlwaysLog flag is set, log the message.
+            // If the log is a catel log and the AlwaysLog flag is set, skip additional checks and log the message.
             var catelLog = log as ICatelLog;
-            if (!catelLog?.AlwaysLog ?? true)
+            if (catelLog == null || !catelLog.AlwaysLog)
             {
                 if (IgnoreCatelLogging && log.IsCatelLogging)
                 {
@@ -223,9 +220,9 @@ namespace Catel.Logging
         /// <param name="time">The time.</param>
         void ILogListener.Info(ILog log, string message, object extraData, LogData logData, DateTime time)
         {
-            // If the log is a catel log and the AlwaysLog flag is set, log the message.
+            // If the log is a catel log and the AlwaysLog flag is set, skip additional checks and log the message.
             var catelLog = log as ICatelLog;
-            if (!catelLog?.AlwaysLog ?? true)
+            if (catelLog == null || !catelLog.AlwaysLog)
             {
                 if (IgnoreCatelLogging && log.IsCatelLogging)
                 {
@@ -251,9 +248,9 @@ namespace Catel.Logging
         /// <param name="time">The time.</param>
         void ILogListener.Warning(ILog log, string message, object extraData, LogData logData, DateTime time)
         {
-            // If the log is a catel log and the AlwaysLog flag is set, log the message.
+            // If the log is a catel log and the AlwaysLog flag is set, skip additional checks and log the message.
             var catelLog = log as ICatelLog;
-            if (!catelLog?.AlwaysLog ?? true)
+            if (catelLog == null || !catelLog.AlwaysLog)
             {
                 if (IgnoreCatelLogging && log.IsCatelLogging)
                 {
@@ -279,9 +276,9 @@ namespace Catel.Logging
         /// <param name="time">The ti me.</param>
         void ILogListener.Error(ILog log, string message, object extraData, LogData logData, DateTime time)
         {
-            // If the log is a catel log and the AlwaysLog flag is set, log the message.
+            // If the log is a catel log and the AlwaysLog flag is set, skip additional checks and log the message.
             var catelLog = log as ICatelLog;
-            if (!catelLog?.AlwaysLog ?? true)
+            if (catelLog == null || !catelLog.AlwaysLog)
             {
                 if (IgnoreCatelLogging && log.IsCatelLogging)
                 {
@@ -307,9 +304,9 @@ namespace Catel.Logging
         /// <param name="time">The ti me.</param>
         void ILogListener.Status(ILog log, string message, object extraData, LogData logData, DateTime time)
         {
-            // If the log is a catel log and the AlwaysLog flag is set, log the message.
+            // If the log is a catel log and the AlwaysLog flag is set, skip additional checks and log the message.
             var catelLog = log as ICatelLog;
-            if (!catelLog?.AlwaysLog ?? true)
+            if (catelLog == null || !catelLog.AlwaysLog)
             {
                 if (IgnoreCatelLogging && log.IsCatelLogging)
             {

--- a/src/Catel.Core/Catel.Core.Shared/Logging/LogListenerBase.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Logging/LogListenerBase.cs
@@ -371,7 +371,7 @@ namespace Catel.Logging
         /// <returns>The formatted log event.</returns>
         protected virtual string FormatLogEvent(ILog log, string message, LogEvent logEvent, object extraData, LogData logData, DateTime time)
         {
-            var logMessage = string.Format("{0} => [{1}] [{2}] [{3}] {4}", time.ToString(_timeFormat), LogEventStrings[logEvent], log.TargetType.FullName, ThreadHelper.GetCurrentThreadId(), message);
+            var logMessage = string.Format("{0} => [{1}] [{2}] [{3}] {4}", time.ToString(_timeFormat), LogEventStrings[logEvent], log.Name, ThreadHelper.GetCurrentThreadId(), message);
             return logMessage;
         }
 

--- a/src/Catel.Core/Catel.Core.Shared/Logging/LogListenerBase.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Logging/LogListenerBase.cs
@@ -9,6 +9,7 @@ namespace Catel.Logging
 {
     using System;
     using System.Collections.Generic;
+    using Interfaces;
 
     /// <summary>
     /// Abstract base class that implements the <see cref="ILogListener"/> interface.
@@ -164,9 +165,9 @@ namespace Catel.Logging
         /// <param name="time">The time.</param>
         void ILogListener.Write(ILog log, string message, LogEvent logEvent, object extraData, LogData logData, DateTime time)
         {
-            // We always want the Argument class logging, no matter what
-            var isArgumentLog = log.TargetType == ArgumentType;
-            if (!isArgumentLog)
+            // If the log is a catel log and the AlwaysLog flag is set, log the message.
+            var catelLog = log as ICatelLog;
+            if (!catelLog?.AlwaysLog ?? true)
             {
                 if (IgnoreCatelLogging && log.IsCatelLogging)
                 {
@@ -194,9 +195,9 @@ namespace Catel.Logging
         /// <param name="time">The time.</param>
         void ILogListener.Debug(ILog log, string message, object extraData, LogData logData, DateTime time)
         {
-            // We always want the Argument class logging, no matter what
-            var isArgumentLog = log.TargetType == ArgumentType;
-            if (!isArgumentLog)
+            // If the log is a catel log and the AlwaysLog flag is set, log the message.
+            var catelLog = log as ICatelLog;
+            if (!catelLog?.AlwaysLog ?? true)
             {
                 if (IgnoreCatelLogging && log.IsCatelLogging)
                 {
@@ -222,9 +223,9 @@ namespace Catel.Logging
         /// <param name="time">The time.</param>
         void ILogListener.Info(ILog log, string message, object extraData, LogData logData, DateTime time)
         {
-            // We always want the Argument class logging, no matter what
-            var isArgumentLog = log.TargetType == ArgumentType;
-            if (!isArgumentLog)
+            // If the log is a catel log and the AlwaysLog flag is set, log the message.
+            var catelLog = log as ICatelLog;
+            if (!catelLog?.AlwaysLog ?? true)
             {
                 if (IgnoreCatelLogging && log.IsCatelLogging)
                 {
@@ -250,9 +251,9 @@ namespace Catel.Logging
         /// <param name="time">The time.</param>
         void ILogListener.Warning(ILog log, string message, object extraData, LogData logData, DateTime time)
         {
-            // We always want the Argument class logging, no matter what
-            var isArgumentLog = log.TargetType == ArgumentType;
-            if (!isArgumentLog)
+            // If the log is a catel log and the AlwaysLog flag is set, log the message.
+            var catelLog = log as ICatelLog;
+            if (!catelLog?.AlwaysLog ?? true)
             {
                 if (IgnoreCatelLogging && log.IsCatelLogging)
                 {
@@ -278,9 +279,9 @@ namespace Catel.Logging
         /// <param name="time">The ti me.</param>
         void ILogListener.Error(ILog log, string message, object extraData, LogData logData, DateTime time)
         {
-            // We always want the Argument class logging, no matter what
-            var isArgumentLog = log.TargetType == ArgumentType;
-            if (!isArgumentLog)
+            // If the log is a catel log and the AlwaysLog flag is set, log the message.
+            var catelLog = log as ICatelLog;
+            if (!catelLog?.AlwaysLog ?? true)
             {
                 if (IgnoreCatelLogging && log.IsCatelLogging)
                 {
@@ -306,9 +307,9 @@ namespace Catel.Logging
         /// <param name="time">The ti me.</param>
         void ILogListener.Status(ILog log, string message, object extraData, LogData logData, DateTime time)
         {
-            // We always want the Argument class logging, no matter what
-            var isArgumentLog = log.TargetType == ArgumentType;
-            if (!isArgumentLog)
+            // If the log is a catel log and the AlwaysLog flag is set, log the message.
+            var catelLog = log as ICatelLog;
+            if (!catelLog?.AlwaysLog ?? true)
             {
                 if (IgnoreCatelLogging && log.IsCatelLogging)
             {

--- a/src/Catel.Core/Catel.Core.Shared/Logging/LogManager.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Logging/LogManager.cs
@@ -11,7 +11,6 @@ namespace Catel.Logging
     using System.Linq;
     using System.Reflection;
     using System.Runtime.CompilerServices;
-    using Interfaces;
     using Reflection;
 #if NET
     using System.Configuration;
@@ -562,10 +561,14 @@ namespace Catel.Logging
 
                     _loggers.Add(name, log);
                 }
-                else if (!(log is ICatelLog))
+                else
                 {
-                    // Handle the unlikely event where a logger with the same name is initialized before the catel logger.
-                    throw new ArgumentException(string.Format("An element with the same key already exists in the {0} and does not implement {1}.", typeof(LogManager).Name, typeof(ICatelLog).Name));
+                    var catelLog = log as ICatelLog;
+                    if (catelLog == null)
+                    {
+                        // Handle the unlikely event where a logger with the same name is initialized before the catel logger.
+                        throw new ArgumentException(string.Format("An element with the same key already exists in the {0} and does not implement {1}.", typeof(LogManager).Name, typeof(ICatelLog).Name));
+                    }
                 }
 
                 return (CatelLog) log;

--- a/src/Catel.Core/Catel.Core.Shared/Logging/LogManager.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Logging/LogManager.cs
@@ -587,6 +587,12 @@ namespace Catel.Logging
 
             lock (_loggers)
             {
+                ILog log;
+                if (!_loggers.TryGetValue(name, out log))
+                    return false;
+
+                log.LogMessage -= OnLogMessage;
+
                 return _loggers.Remove(name);
             }
         }

--- a/src/Catel.Core/Catel.Core.Shared/Logging/LogManager.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Logging/LogManager.cs
@@ -561,17 +561,15 @@ namespace Catel.Logging
 
                     _loggers.Add(name, log);
                 }
-                else
+
+                var catelLog = log as ICatelLog;
+                if (catelLog == null)
                 {
-                    var catelLog = log as ICatelLog;
-                    if (catelLog == null)
-                    {
-                        // Handle the unlikely event where a logger with the same name is initialized before the catel logger.
-                        throw new ArgumentException(string.Format("An element with the same key already exists in the {0} and does not implement {1}.", typeof(LogManager).Name, typeof(ICatelLog).Name));
-                    }
+                    // Handle the unlikely event where a logger with the same name is initialized before the catel logger.
+                    throw new ArgumentException(string.Format("An element with the same key already exists in the {0} and does not implement {1}.", typeof(LogManager).Name, typeof(ICatelLog).Name));
                 }
 
-                return (CatelLog) log;
+                return catelLog;
             }
         }
 
@@ -589,7 +587,9 @@ namespace Catel.Logging
             {
                 ILog log;
                 if (!_loggers.TryGetValue(name, out log))
+                {
                     return false;
+                }
 
                 log.LogMessage -= OnLogMessage;
 

--- a/src/Catel.Core/Catel.Core.Shared/Logging/LogManager.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Logging/LogManager.cs
@@ -576,6 +576,22 @@ namespace Catel.Logging
         }
 
         /// <summary>
+        /// Removes the logger with the specified name from the <see cref="LogManager"/>.
+        /// </summary>
+        /// <param name="name">The name of the logger.</param>
+        /// <returns>true if the logger is successfully found and removed; otherwise, false. This method returns false if <paramref name="name"/> is not found in the <see cref="LogManager"/>.</returns>
+        /// <exception cref="ArgumentException">If <paramref name="name"/> is null or a whitespace.</exception>
+        internal static bool RemoveLogger(string name)
+        {
+            Argument.IsNotNullOrWhitespace("name", name);
+
+            lock (_loggers)
+            {
+                return _loggers.Remove(name);
+            }
+        }
+
+        /// <summary>
         /// Flushes all listeners that implement the <see cref="IBatchLogListener" /> by calling <see cref="IBatchLogListener.Flush" />.
         /// </summary>
         public static void FlushAll()

--- a/src/Catel.Core/Catel.Core.Shared/Logging/LogManager.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Logging/LogManager.cs
@@ -468,19 +468,7 @@ namespace Catel.Logging
         /// <returns>The <see cref="ILog"/> object for the specified type.</returns>
         public static ILog GetLogger<T>()
         {
-            lock (_loggers)
-            {
-                var key = typeof(T).ToString();
-                if (!_loggers.ContainsKey(key))
-                {
-                    var log = new Log(typeof(T));
-                    log.LogMessage += OnLogMessage;
-
-                    _loggers.Add(key, log);
-                }
-
-                return _loggers[key];
-            }
+            return GetLogger(typeof(T));
         }
 
         /// <summary>
@@ -488,24 +476,12 @@ namespace Catel.Logging
         /// </summary>
         /// <param name="type">The type.</param>
         /// <returns>The <see cref="ILog"/> object for the specified type.</returns>
-        /// <exception cref="ArgumentNullException">If <paramref name="type"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="type"/> is <c>null</c>.</exception>
         public static ILog GetLogger(Type type)
         {
             Argument.IsNotNull("type", type);
 
-            lock (_loggers)
-            {
-                var key = type.ToString();
-                if (!_loggers.ContainsKey(key))
-                {
-                    var log = new Log(type);
-                    log.LogMessage += OnLogMessage;
-
-                    _loggers.Add(key, log);
-                }
-
-                return _loggers[key];
-            }
+            return GetLogger(type.FullName);
         }
 
         /// <summary>
@@ -520,15 +496,16 @@ namespace Catel.Logging
 
             lock (_loggers)
             {
-                if (!_loggers.ContainsKey(name))
+                ILog log;
+                if (!_loggers.TryGetValue(name, out log))
                 {
-                    var log = new Log(name);
+                    log = new Log(name);
                     log.LogMessage += OnLogMessage;
 
                     _loggers.Add(name, log);
                 }
 
-                return _loggers[name];
+                return log;
             }
         }
 

--- a/src/Catel.Test/Catel.Test.Shared/Catel.Test.Shared.projitems
+++ b/src/Catel.Test/Catel.Test.Shared/Catel.Test.Shared.projitems
@@ -129,6 +129,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)IoC\TypeRequestPathFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IO\Extensions\StreamExtensionsFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IO\PathTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Logging\CatelLogFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Logging\Configuration\LoggingConfigurationSectionFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Logging\EventArgs\LogMessageEventArgsTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Logging\Listeners\FileLogListenerFacts.cs" />

--- a/src/Catel.Test/Catel.Test.Shared/Logging/CatelLogFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Logging/CatelLogFacts.cs
@@ -1,0 +1,442 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CatelLogFacts.cs" company="Catel development team">
+//   Copyright (c) 2016 Catel development team. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Catel.Test.Logging
+{
+    using Catel.Logging;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class CatelLogFacts
+    {
+        private CatelLog _logger;
+        private CatelLog Logger
+        {
+            get { return _logger ?? (_logger = (CatelLog) LogManager.GetCatelLogger(typeof(CatelLogFacts), AlwaysLog)); }
+            set { _logger = value; }
+        }
+
+        private bool AlwaysLog { get; set; }
+        private ILogListener FakeListener { get; set; }
+
+        /// <summary>
+        /// Use Test_Initialize to run code before running each test.
+        /// </summary>
+        [SetUp]
+        public void Test_Initialize()
+        {
+            AlwaysLog = true;
+            FakeListener = LogManager.AddDebugListener();
+            FakeListener.IgnoreCatelLogging = true;
+        }
+
+        /// <summary>
+        /// Use Test_Cleanup to run code after each test has run.
+        /// </summary>
+        [TearDown]
+        public void Test_Cleanup()
+        {
+            LogManager.RemoveLogger(typeof(CatelLogFacts).FullName);
+            LogManager.RemoveListener(FakeListener);
+            Logger = null;
+        }
+
+        [Test]
+        public void Debug_AlwaysLogIsTrue_IgnoreCatelLogsIsTrue_WritesLog()
+        {
+            // ARRANGE
+            const LogEvent expectedLogEvent = LogEvent.Debug;
+            const string expectedMessage = "A message";
+
+            var receivedLog = false;
+            FakeListener.LogMessage += (sender, e) =>
+                {
+                    receivedLog = true;
+                    Assert.NotNull(e);
+                    Assert.AreEqual(expectedLogEvent, e.LogEvent);
+                    Assert.AreEqual(expectedMessage, e.Message);
+                };
+
+            Assert.IsTrue(FakeListener.IgnoreCatelLogging);
+
+            // ACT
+            Logger.Write(expectedLogEvent, expectedMessage);
+
+
+            // ASSERT
+            Assert.IsTrue(receivedLog);
+        }
+        
+        [Test]
+        public void Debug_AlwaysLogIsFalse_IgnoreCatelLogsIsTrue_DoesNotWriteLog()
+        {
+            // ARRANGE
+            const LogEvent expectedLogEvent = LogEvent.Debug;
+            const string expectedMessage = "A message";
+
+            AlwaysLog = false;
+
+            FakeListener.LogMessage += (sender, e) =>
+                {
+                    Assert.Fail();
+                };
+
+            Assert.IsTrue(FakeListener.IgnoreCatelLogging);
+
+            // ACT
+            Logger.Write(expectedLogEvent, expectedMessage);
+
+
+            // ASSERT
+            // did not log to listener
+        }
+
+        [Test]
+        public void Debug_AlwaysLogIsFalse_IgnoreCatelLogsIsFalse_WritesLog()
+        {
+            // ARRANGE
+            const LogEvent expectedLogEvent = LogEvent.Debug;
+            const string expectedMessage = "A message";
+
+            AlwaysLog = false;
+            FakeListener.IgnoreCatelLogging = false;
+
+            var receivedLog = false;
+            FakeListener.LogMessage += (sender, e) =>
+                {
+                    receivedLog = true;
+                    Assert.NotNull(e);
+                    Assert.AreEqual(expectedLogEvent, e.LogEvent);
+                    Assert.AreEqual(expectedMessage, e.Message);
+                };
+
+            Assert.IsFalse(FakeListener.IgnoreCatelLogging);
+
+            // ACT
+            Logger.Write(expectedLogEvent, expectedMessage);
+
+
+            // ASSERT
+            Assert.IsTrue(receivedLog);
+        }
+
+        [Test]
+        public void Error_AlwaysLogIsTrue_IgnoreCatelLogsIsTrue_WritesLog()
+        {
+            // ARRANGE
+            const LogEvent expectedLogEvent = LogEvent.Error;
+            const string expectedMessage = "A message";
+
+            var receivedLog = false;
+            FakeListener.LogMessage += (sender, e) =>
+                {
+                    receivedLog = true;
+                    Assert.NotNull(e);
+                    Assert.AreEqual(expectedLogEvent, e.LogEvent);
+                    Assert.AreEqual(expectedMessage, e.Message);
+                };
+
+            Assert.IsTrue(FakeListener.IgnoreCatelLogging);
+
+            // ACT
+            Logger.Write(expectedLogEvent, expectedMessage);
+
+
+            // ASSERT
+            Assert.IsTrue(receivedLog);
+        }
+
+        [Test]
+        public void Error_AlwaysLogIsFalse_IgnoreCatelLogsIsTrue_DoesNotWriteLog()
+        {
+            // ARRANGE
+            const LogEvent expectedLogEvent = LogEvent.Error;
+            const string expectedMessage = "A message";
+
+            AlwaysLog = false;
+
+            FakeListener.LogMessage += (sender, e) =>
+                {
+                    Assert.Fail();
+                };
+
+            Assert.IsTrue(FakeListener.IgnoreCatelLogging);
+
+            // ACT
+            Logger.Write(expectedLogEvent, expectedMessage);
+
+
+            // ASSERT
+            // did not log to listener
+        }
+
+        [Test]
+        public void Error_AlwaysLogIsFalse_IgnoreCatelLogsIsFalse_WritesLog()
+        {
+            // ARRANGE
+            const LogEvent expectedLogEvent = LogEvent.Error;
+            const string expectedMessage = "A message";
+
+            AlwaysLog = false;
+            FakeListener.IgnoreCatelLogging = false;
+
+            var receivedLog = false;
+            FakeListener.LogMessage += (sender, e) =>
+                {
+                    receivedLog = true;
+                    Assert.NotNull(e);
+                    Assert.AreEqual(expectedLogEvent, e.LogEvent);
+                    Assert.AreEqual(expectedMessage, e.Message);
+                };
+
+            Assert.IsFalse(FakeListener.IgnoreCatelLogging);
+
+            // ACT
+            Logger.Write(expectedLogEvent, expectedMessage);
+
+
+            // ASSERT
+            Assert.IsTrue(receivedLog);
+        }
+
+        [Test]
+        public void Info_AlwaysLogIsTrue_IgnoreCatelLogsIsTrue_WritesLog()
+        {
+            // ARRANGE
+            const LogEvent expectedLogEvent = LogEvent.Info;
+            const string expectedMessage = "A message";
+
+            var receivedLog = false;
+            FakeListener.LogMessage += (sender, e) =>
+                {
+                    receivedLog = true;
+                    Assert.NotNull(e);
+                    Assert.AreEqual(expectedLogEvent, e.LogEvent);
+                    Assert.AreEqual(expectedMessage, e.Message);
+                };
+
+            Assert.IsTrue(FakeListener.IgnoreCatelLogging);
+
+            // ACT
+            Logger.Write(expectedLogEvent, expectedMessage);
+
+
+            // ASSERT
+            Assert.IsTrue(receivedLog);
+        }
+
+        [Test]
+        public void Info_AlwaysLogIsFalse_IgnoreCatelLogsIsTrue_DoesNotWriteLog()
+        {
+            // ARRANGE
+            const LogEvent expectedLogEvent = LogEvent.Info;
+            const string expectedMessage = "A message";
+
+            AlwaysLog = false;
+
+            FakeListener.LogMessage += (sender, e) =>
+                {
+                    Assert.Fail();
+                };
+
+            Assert.IsTrue(FakeListener.IgnoreCatelLogging);
+
+            // ACT
+            Logger.Write(expectedLogEvent, expectedMessage);
+
+
+            // ASSERT
+            // did not log to listener
+        }
+
+        [Test]
+        public void Info_AlwaysLogIsFalse_IgnoreCatelLogsIsFalse_WritesLog()
+        {
+            // ARRANGE
+            const LogEvent expectedLogEvent = LogEvent.Info;
+            const string expectedMessage = "A message";
+
+            AlwaysLog = false;
+            FakeListener.IgnoreCatelLogging = false;
+
+            var receivedLog = false;
+            FakeListener.LogMessage += (sender, e) =>
+                {
+                    receivedLog = true;
+                    Assert.NotNull(e);
+                    Assert.AreEqual(expectedLogEvent, e.LogEvent);
+                    Assert.AreEqual(expectedMessage, e.Message);
+                };
+
+            Assert.IsFalse(FakeListener.IgnoreCatelLogging);
+
+            // ACT
+            Logger.Write(expectedLogEvent, expectedMessage);
+
+
+            // ASSERT
+            Assert.IsTrue(receivedLog);
+        }
+
+        [Test]
+        public void Status_AlwaysLogIsTrue_IgnoreCatelLogsIsTrue_WritesLog()
+        {
+            // ARRANGE
+            const LogEvent expectedLogEvent = LogEvent.Status;
+            const string expectedMessage = "A message";
+
+            var receivedLog = false;
+            FakeListener.LogMessage += (sender, e) =>
+                {
+                    receivedLog = true;
+                    Assert.NotNull(e);
+                    Assert.AreEqual(expectedLogEvent, e.LogEvent);
+                    Assert.AreEqual(expectedMessage, e.Message);
+                };
+
+            Assert.IsTrue(FakeListener.IgnoreCatelLogging);
+
+            // ACT
+            Logger.Write(expectedLogEvent, expectedMessage);
+
+
+            // ASSERT
+            Assert.IsTrue(receivedLog);
+        }
+
+        [Test]
+        public void Status_AlwaysLogIsFalse_IgnoreCatelLogsIsTrue_DoesNotWriteWriteLog()
+        {
+            // ARRANGE
+            const LogEvent expectedLogEvent = LogEvent.Status;
+            const string expectedMessage = "A message";
+
+            AlwaysLog = false;
+
+            FakeListener.LogMessage += (sender, e) =>
+                {
+                    Assert.Fail();
+                };
+
+            Assert.IsTrue(FakeListener.IgnoreCatelLogging);
+
+            // ACT
+            Logger.Write(expectedLogEvent, expectedMessage);
+
+
+            // ASSERT
+            // did not log to listener
+        }
+
+        [Test]
+        public void Status_AlwaysLogIsFalse_IgnoreCatelLogsIsFalse_WritesLog()
+        {
+            // ARRANGE
+            const LogEvent expectedLogEvent = LogEvent.Status;
+            const string expectedMessage = "A message";
+
+            AlwaysLog = false;
+            FakeListener.IgnoreCatelLogging = false;
+
+            var receivedLog = false;
+            FakeListener.LogMessage += (sender, e) =>
+                {
+                    receivedLog = true;
+                    Assert.NotNull(e);
+                    Assert.AreEqual(expectedLogEvent, e.LogEvent);
+                    Assert.AreEqual(expectedMessage, e.Message);
+                };
+
+            Assert.IsFalse(FakeListener.IgnoreCatelLogging);
+
+            // ACT
+            Logger.Write(expectedLogEvent, expectedMessage);
+
+
+            // ASSERT
+            Assert.IsTrue(receivedLog);
+        }
+
+        [Test]
+        public void Warning_AlwaysLogIsTrue_IgnoreCatelLogsIsTrue_WritesLog()
+        {
+            // ARRANGE
+            const LogEvent expectedLogEvent = LogEvent.Warning;
+            const string expectedMessage = "A message";
+
+            var receivedLog = false;
+            FakeListener.LogMessage += (sender, e) =>
+                {
+                    receivedLog = true;
+                    Assert.NotNull(e);
+                    Assert.AreEqual(expectedLogEvent, e.LogEvent);
+                    Assert.AreEqual(expectedMessage, e.Message);
+                };
+
+            Assert.IsTrue(FakeListener.IgnoreCatelLogging);
+
+            // ACT
+            Logger.Write(expectedLogEvent, expectedMessage);
+
+
+            // ASSERT
+            Assert.IsTrue(receivedLog);
+        }
+
+        [Test]
+        public void Warning_AlwaysLogIsFalse_IgnoreCatelLogsIsTrue_DoesNotWriteLog()
+        {
+            // ARRANGE
+            const LogEvent expectedLogEvent = LogEvent.Warning;
+            const string expectedMessage = "A message";
+
+            AlwaysLog = false;
+
+            FakeListener.LogMessage += (sender, e) =>
+                {
+                    Assert.Fail();
+                };
+
+            Assert.IsTrue(FakeListener.IgnoreCatelLogging);
+
+            // ACT
+            Logger.Write(expectedLogEvent, expectedMessage);
+
+
+            // ASSERT
+            // did not log to listener
+        }
+
+        [Test]
+        public void Warning_AlwaysLogIsFalse_IgnoreCatelLogsIsFalse_WritesLog()
+        {
+            // ARRANGE
+            const LogEvent expectedLogEvent = LogEvent.Warning;
+            const string expectedMessage = "A message";
+
+            AlwaysLog = false;
+            FakeListener.IgnoreCatelLogging = false;
+
+            var receivedLog = false;
+            FakeListener.LogMessage += (sender, e) =>
+                {
+                    receivedLog = true;
+                    Assert.NotNull(e);
+                    Assert.AreEqual(expectedLogEvent, e.LogEvent);
+                    Assert.AreEqual(expectedMessage, e.Message);
+                };
+
+            Assert.IsFalse(FakeListener.IgnoreCatelLogging);
+
+            // ACT
+            Logger.Write(expectedLogEvent, expectedMessage);
+
+
+            // ASSERT
+            Assert.IsTrue(receivedLog);
+        }
+    }
+}

--- a/src/Catel.Test/Catel.Test.Shared/Logging/LogFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Logging/LogFacts.cs
@@ -177,7 +177,7 @@ namespace Catel.Test.Logging
             [TestCase]
             public void ThrowsArgumentNullExceptionForNullType()
             {
-                ExceptionTester.CallMethodAndExpectException<ArgumentNullException>(() => new Log((Type) null));
+                ExceptionTester.CallMethodAndExpectException<ArgumentException>(() => new Log((Type) null));
             }
 
             [TestCase]
@@ -202,12 +202,6 @@ namespace Catel.Test.Logging
             public void ThrowsArgumentExceptionForWhitespaceString_WithStringAndType()
             {
                 ExceptionTester.CallMethodAndExpectException<ArgumentException>(() => new Log(String.Empty, typeof(object)));
-            }
-
-            [TestCase]
-            public void ThrowsArgumentNullExceptionForNullType_WithStringAndType()
-            {
-                ExceptionTester.CallMethodAndExpectException<ArgumentNullException>(() => new Log("log", null));
             }
 
             [TestCase]

--- a/src/Catel.Test/Catel.Test.Shared/Logging/LogFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Logging/LogFacts.cs
@@ -177,7 +177,37 @@ namespace Catel.Test.Logging
             [TestCase]
             public void ThrowsArgumentNullExceptionForNullType()
             {
-                ExceptionTester.CallMethodAndExpectException<ArgumentNullException>(() => new Log(null));
+                ExceptionTester.CallMethodAndExpectException<ArgumentNullException>(() => new Log((Type) null));
+            }
+
+            [TestCase]
+            public void ThrowsArgumentExceptionForNullString()
+            {
+                ExceptionTester.CallMethodAndExpectException<ArgumentException>(() => new Log((string)null));
+            }
+
+            [TestCase]
+            public void ThrowsArgumentExceptionForWhitespaceString()
+            {
+                ExceptionTester.CallMethodAndExpectException<ArgumentException>(() => new Log(String.Empty));
+            }
+
+            [TestCase]
+            public void ThrowsArgumentExceptionForNullString_WithStringAndType()
+            {
+                ExceptionTester.CallMethodAndExpectException<ArgumentException>(() => new Log(null, typeof(object)));
+            }
+
+            [TestCase]
+            public void ThrowsArgumentExceptionForWhitespaceString_WithStringAndType()
+            {
+                ExceptionTester.CallMethodAndExpectException<ArgumentException>(() => new Log(String.Empty, typeof(object)));
+            }
+
+            [TestCase]
+            public void ThrowsArgumentNullExceptionForNullType_WithStringAndType()
+            {
+                ExceptionTester.CallMethodAndExpectException<ArgumentNullException>(() => new Log("log", null));
             }
 
             [TestCase]
@@ -186,6 +216,26 @@ namespace Catel.Test.Logging
                 LogManager.AddDebugListener();
                 var log = new Log(typeof(int));
 
+                Assert.AreEqual(typeof(int), log.TargetType);
+            }
+
+            [TestCase]
+            public void CreatesLogForString()
+            {
+                LogManager.AddDebugListener();
+                var log = new Log("log");
+
+                Assert.AreEqual("log", log.Name);
+                Assert.IsNull(log.TargetType);
+            }
+
+            [TestCase]
+            public void CreatesLogForStringAndType()
+            {
+                LogManager.AddDebugListener();
+                var log = new Log("log", typeof(int));
+
+                Assert.AreEqual("log", log.Name);
                 Assert.AreEqual(typeof(int), log.TargetType);
             }
         }

--- a/src/Catel.Test/Catel.Test.Shared/Logging/LogManagerTest.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Logging/LogManagerTest.cs
@@ -212,16 +212,37 @@ namespace Catel.Test.Logging
         }
 
         [TestCase]
-        public void GetLogger_Null()
+        public void GetLogger_NullType()
         {
-            ExceptionTester.CallMethodAndExpectException<ArgumentNullException>(() => LogManager.GetLogger(null));
+            ExceptionTester.CallMethodAndExpectException<ArgumentNullException>(() => LogManager.GetLogger((Type) null));
         }
 
         [TestCase]
-        public void GetLogger_CheckIfSameLogIsReturned()
+        public void GetLogger_NullString()
+        {
+            ExceptionTester.CallMethodAndExpectException<ArgumentException>(() => LogManager.GetLogger((string) null));
+        }
+
+        [TestCase]
+        public void GetLogger_EmptyString()
+        {
+            ExceptionTester.CallMethodAndExpectException<ArgumentException>(() => LogManager.GetLogger(String.Empty));
+        }
+
+        [TestCase]
+        public void GetLogger_Type_CheckIfSameLogIsReturned()
         {
             var log1 = LogManager.GetLogger(typeof(int));
             var log2 = LogManager.GetLogger(typeof(int));
+
+            Assert.IsTrue(ReferenceEquals(log1, log2));
+        }
+
+        [TestCase]
+        public void GetLogger_String_CheckIfSameLogIsReturned()
+        {
+            var log1 = LogManager.GetLogger("log");
+            var log2 = LogManager.GetLogger("log");
 
             Assert.IsTrue(ReferenceEquals(log1, log2));
         }


### PR DESCRIPTION
[https://catelproject.atlassian.net/browse/CTL-923](Refactor Loggers to Bind to Strings Instead of Types)

This has the TargetType property still implemented; need to make a decision if we want to remove or keep it.