### PR TITLE
CTL-991 Equals method in ServiceLocator.ServiceInfo class returns false positives

### DIFF
--- a/src/Catel.Core/Catel.Core.Shared/IoC/ServiceLocator.cs
+++ b/src/Catel.Core/Catel.Core.Shared/IoC/ServiceLocator.cs
@@ -40,13 +40,14 @@ namespace Catel.IoC
         [DebuggerDisplay("{Type} ({Tag})")]
         private class ServiceInfo
         {
-            private int _hash;
+            private readonly int _hash;
 
             #region Constructors
             public ServiceInfo(Type type, object tag)
             {
                 Type = type;
                 Tag = tag;
+                _hash = HashHelper.CombineHash(Type.GetHashCode(), Tag != null ? Tag.GetHashCode() : 0);
             }
             #endregion
 
@@ -54,25 +55,13 @@ namespace Catel.IoC
             public Type Type { get; private set; }
 
             public object Tag { get; private set; }
-
-            public int Hash
-            {
-                get
-                {
-                    if (_hash == 0)
-                    {
-                        _hash = HashHelper.CombineHash(Type.GetHashCode(), Tag != null ? Tag.GetHashCode() : 0);
-                    }
-
-                    return _hash;
-                }
-            }
+            
             #endregion
 
             #region Methods
             public override int GetHashCode()
             {
-                return Hash;
+                return _hash;
             }
 
             public override bool Equals(object obj)
@@ -83,7 +72,16 @@ namespace Catel.IoC
                     return false;
                 }
 
-                return objAsServiceInfo.Hash == Hash;
+                if (objAsServiceInfo._hash != _hash)
+                {
+                    return false;
+                }
+                if (objAsServiceInfo.Type != Type)
+                {
+                    return false;
+                }
+
+                return Equals(objAsServiceInfo.Tag, Tag);
             }
             #endregion
         }


### PR DESCRIPTION
Fixes # .

### Checklist

- [ ] I have included examples or tests - It causes problems in very rare case hard to reproduce
- [ ] I have updated the change log - I'm not sure what version it will be released. Mine sugestion is to release it ASAP. I have base mine solution on hotfix/4.5.4 branch.
- [x] I am listed in the CONTRIBUTORS file - I'm already there (for 5.0.0 version)
- [ ] I have cleaned up the commit history (use rebase and squash) - Not done

### Changes proposed in this pull request:

- hashcode of class if computed in constructor because hashcode and equals are the only reasons for this class to exists
- I compare types first it should be faster than comparing Tags. Tags are nulls in most cases so it will return true anywhere, Tags can also implement complex logic in Equals method Type uses default implementation as I know and should return false in most cases.


Equals method in ServiceLocator.ServiceInfo class returns false positives