### PR TITLE
Bugfix/ctl 991 equals method in service locator service info class returns false positives v2

### DIFF
--- a/doc/history.txt
+++ b/doc/history.txt
@@ -69,6 +69,7 @@ Added/fixed:
 (*) CTL-922 Don't cache RootFrame in NavigationService to allow dynamic navigation frames
 (*) CTL-941 Update to json.net 9.x
 (*) CTL-988 Allow view models without model injection to stay alive on DataContext changes
+(x) CTL-991 Equals method in ServiceLocator.ServiceInfo class returns false positives
 (x) CTL-899 Navigation in WPF is not working when using custom frame
 (x) CTL-906 Clear current navigation context when (re)navigating to the same view in WPF
 (x) CTL-910 Introduce special lock for null keys in CacheStorage to prevent ArgumentNullException

--- a/doc/history.txt
+++ b/doc/history.txt
@@ -69,12 +69,12 @@ Added/fixed:
 (*) CTL-922 Don't cache RootFrame in NavigationService to allow dynamic navigation frames
 (*) CTL-941 Update to json.net 9.x
 (*) CTL-988 Allow view models without model injection to stay alive on DataContext changes
-(x) CTL-991 Equals method in ServiceLocator.ServiceInfo class returns false positives
 (x) CTL-899 Navigation in WPF is not working when using custom frame
 (x) CTL-906 Clear current navigation context when (re)navigating to the same view in WPF
 (x) CTL-910 Introduce special lock for null keys in CacheStorage to prevent ArgumentNullException
 (x) CTL-925 LanguageBinding markup now uses weak events to allow specific controls (such as the ComboBox with ComboBoxItem 
     elements) to be updated after they have been collapsed
+(x) CTL-991 Equals method in ServiceLocator.ServiceInfo class returns false positives
 (-) CTL-935 Remove InterestedIn attributes because services are a better way to communicate 
 (-) Removed test implementations of services
 

--- a/src/Catel.Core/Catel.Core.Shared/IoC/ServiceLocator.cs
+++ b/src/Catel.Core/Catel.Core.Shared/IoC/ServiceLocator.cs
@@ -40,13 +40,14 @@ namespace Catel.IoC
         [DebuggerDisplay("{Type} ({Tag})")]
         private class ServiceInfo
         {
-            private int _hash;
+            private readonly int _hash;
 
             #region Constructors
             public ServiceInfo(Type type, object tag)
             {
                 Type = type;
                 Tag = tag;
+                _hash = HashHelper.CombineHash(Type.GetHashCode(), Tag != null ? Tag.GetHashCode() : 0);
             }
             #endregion
 
@@ -54,25 +55,13 @@ namespace Catel.IoC
             public Type Type { get; private set; }
 
             public object Tag { get; private set; }
-
-            public int Hash
-            {
-                get
-                {
-                    if (_hash == 0)
-                    {
-                        _hash = HashHelper.CombineHash(Type.GetHashCode(), Tag != null ? Tag.GetHashCode() : 0);
-                    }
-
-                    return _hash;
-                }
-            }
+            
             #endregion
 
             #region Methods
             public override int GetHashCode()
             {
-                return Hash;
+                return _hash;
             }
 
             public override bool Equals(object obj)
@@ -83,7 +72,16 @@ namespace Catel.IoC
                     return false;
                 }
 
-                return objAsServiceInfo.Hash == Hash;
+                if (objAsServiceInfo._hash != _hash)
+                {
+                    return false;
+                }
+                if (objAsServiceInfo.Type != Type)
+                {
+                    return false;
+                }
+
+                return Equals(objAsServiceInfo.Tag, Tag);
             }
             #endregion
         }


### PR DESCRIPTION
Fixes # .

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Hash is computed in constructor there is no need to delay this operation
- Equals function works more properly 
-
