### PR TITLE
Bugfix/ctl 999 double click to command causes memory leaks

### DIFF
--- a/doc/history.txt
+++ b/doc/history.txt
@@ -75,6 +75,7 @@ Added/fixed:
 (x) CTL-925 LanguageBinding markup now uses weak events to allow specific controls (such as the ComboBox with ComboBoxItem 
     elements) to be updated after they have been collapsed
 (x) CTL-991 Equals method in ServiceLocator.ServiceInfo class returns false positives
+(x) CTL-999 DoubleClickToCommand shouldn't cause memory leaks
 (-) CTL-935 Remove InterestedIn attributes because services are a better way to communicate 
 (-) CTL-975 Remove EventHandlerExtensions.SplitInvoke and use regular event invocation
 (-) CTL-987 Delete MVVM logic behaviors (should only be available as logic)

--- a/src/Catel.Core/Catel.Core.Shared/Catel.Core.Shared.projitems
+++ b/src/Catel.Core/Catel.Core.Shared/Catel.Core.Shared.projitems
@@ -147,6 +147,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)EventHandlerExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EventHandlers\AsyncEventHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EventHandlers\Extensions\AsyncEventHandlerExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)EventWrappers\WeakEventHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExceptionHandling\EventArgs\BufferedEventArgs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExceptionHandling\EventArgs\RetryingEventArgs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExceptionHandling\ExceptionHandler.cs" />

--- a/src/Catel.Core/Catel.Core.Shared/Catel.Core.Shared.projitems
+++ b/src/Catel.Core/Catel.Core.Shared/Catel.Core.Shared.projitems
@@ -147,7 +147,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)EventHandlerExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EventHandlers\AsyncEventHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EventHandlers\Extensions\AsyncEventHandlerExtensions.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)EventWrappers\WeakEventHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExceptionHandling\EventArgs\BufferedEventArgs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExceptionHandling\EventArgs\RetryingEventArgs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExceptionHandling\ExceptionHandler.cs" />
@@ -431,6 +430,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)WeakReferences\Interfaces\IWeakEventListener.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WeakReferences\Interfaces\IWeakReference.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WeakReferences\WeakAction.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)WeakReferences\WeakEventHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WeakReferences\WeakEventListener.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Catel.Core/Catel.Core.Shared/EventWrappers/WeakEventHandler.cs
+++ b/src/Catel.Core/Catel.Core.Shared/EventWrappers/WeakEventHandler.cs
@@ -1,0 +1,173 @@
+﻿namespace Catel.EventWrappers
+{
+    using System;
+
+    /// <summary>
+    /// Provides helpers that ease subscription to events that should be auto-detached if it is the only reference between observer and observed
+    /// </summary>
+    public static class WeakEventHandler
+    {
+        /// <summary>
+        /// Subscribes weakly event-handler to event
+        /// </summary>
+        /// <example>
+        /// WeakEventHandler
+        ///     .Subscribe(
+        ///         source, 
+        ///         OnSomethingHappens, 
+        ///         (s, handler) => s.SomethingHappens += handler,
+        ///         (s, handler) => s.SomethingHappens += handler)
+        /// </example>
+        /// <typeparam name="TSource">Type of observed object</typeparam>
+        /// <param name="source">Observed object</param>
+        /// <param name="eventHandler">Method that should be called when event is raised</param>
+        /// <param name="attachAction">It should contains (source, handler) => source.Event += handler</param>
+        /// <param name="detachAction">It should contains (source, handler) => source.Event -= handler</param>
+        /// <returns>Disposing of result allows manual detach</returns>
+        public static IDisposable Subscribe<TSource>(
+            TSource source,
+            EventHandler eventHandler,
+            Action<TSource, EventHandler> attachAction,
+            Action<TSource, EventHandler> detachAction)
+        {
+            return new WeakEventWrapper<TSource>(source, eventHandler, attachAction, detachAction);
+        }
+
+        /// <summary>
+        /// Subscribes weakly event-handler to event
+        /// </summary>
+        /// <example>
+        /// WeakEventHandler
+        ///     .Subscribe(
+        ///         source, 
+        ///         OnSomethingHappens, 
+        ///         (s, handler) => s.SomethingHappens += handler,
+        ///         (s, handler) => s.SomethingHappens += handler)
+        /// </example>
+        /// <typeparam name="TSource">Type of observed object</typeparam>
+        /// <typeparam name="TArgs">Type of event&apos;s argument</typeparam>
+        /// <param name="source">Observed object</param>
+        /// <param name="eventHandler">Method that should be called when event is raised</param>
+        /// <param name="attachAction">It should contains (source, handler) => source.Event += handler</param>
+        /// <param name="detachAction">It should contains (source, handler) => source.Event -= handler</param>
+        /// <returns>Disposing of result allows manual detach</returns>
+        public static IDisposable Subscribe<TSource, TArgs>(
+            TSource source,
+            EventHandler<TArgs> eventHandler,
+            Action<TSource, EventHandler<TArgs>> attachAction,
+            Action<TSource, EventHandler<TArgs>> detachAction) where TArgs : EventArgs
+        {
+            return new WeakEventWrapper<TSource, TArgs>(source, eventHandler, attachAction, detachAction);
+        }
+        
+        private sealed class WeakEventWrapper<TSource>: IDisposable
+        {
+            private readonly TSource _source;
+            private readonly Action<TSource, EventHandler> _detachAction;
+            private readonly WeakReference<EventHandler> _handlerReference;
+            
+            public WeakEventWrapper(
+                TSource source,
+                EventHandler handler,
+                Action<TSource, EventHandler> attachAction,
+                Action<TSource, EventHandler> detachAction)
+            {
+                _source = source;
+                _detachAction = detachAction;
+                _handlerReference = new WeakReference<EventHandler>(handler);
+                attachAction(source, OnEvent);
+            }
+
+            private void OnEvent(object sender, EventArgs e)
+            {
+                EventHandler eventHandler;
+                if (_handlerReference.TryGetTarget(out eventHandler))
+                {
+                    eventHandler(sender, e);
+                }
+                else
+                {
+                    // This method shouldn't be called internally but it makes sense in here
+                    Dispose();
+                }
+            }
+
+            #region IDisposable
+
+            public void Dispose()
+            {
+                Dispose(true);
+                GC.SuppressFinalize(this);
+            }
+
+            // ReSharper disable once UnusedParameter.Local
+            private void Dispose(bool isDisposing)
+            {
+                _detachAction(_source, OnEvent);
+            }
+
+            ~WeakEventWrapper()
+            {
+                Dispose(false);
+            }
+
+            #endregion
+        }
+
+        // Code duplication but I have no idea how to avoid it
+
+        private sealed class WeakEventWrapper<TSource, TArgs> : IDisposable where TArgs : EventArgs
+        {
+            private readonly TSource _source;
+            private readonly Action<TSource, EventHandler<TArgs>> _detachAction;
+            private readonly WeakReference<EventHandler<TArgs>> _handlerReference;
+
+            public WeakEventWrapper(
+                TSource source,
+                EventHandler<TArgs> handler,
+                Action<TSource, EventHandler<TArgs>> attachAction,
+                Action<TSource, EventHandler<TArgs>> detachAction)
+            {
+                _source = source;
+                _detachAction = detachAction;
+                _handlerReference = new WeakReference<EventHandler<TArgs>>(handler);
+                attachAction(source, OnEvent);
+            }
+
+            private void OnEvent(object sender, TArgs e)
+            {
+                EventHandler<TArgs> eventHandler;
+                if (_handlerReference.TryGetTarget(out eventHandler))
+                {
+                    eventHandler(sender, e);
+                }
+                else
+                {
+                    // This method shouldn't be called internally but it makes sense in here
+                    Dispose();
+                }
+            }
+
+            #region IDisposable
+
+            public void Dispose()
+            {
+                Dispose(true);
+                GC.SuppressFinalize(this);
+            }
+
+            // ReSharper disable once UnusedParameter.Local
+            private void Dispose(bool isDisposing)
+            {
+                _detachAction(_source, OnEvent);
+            }
+
+            ~WeakEventWrapper()
+            {
+                Dispose(false);
+            }
+
+            #endregion
+        }
+    }
+}

--- a/src/Catel.Core/Catel.Core.Shared/WeakReferences/WeakEventHandler.cs
+++ b/src/Catel.Core/Catel.Core.Shared/WeakReferences/WeakEventHandler.cs
@@ -1,4 +1,4 @@
-﻿namespace Catel.EventWrappers
+﻿namespace Catel
 {
     using System;
 

--- a/src/Catel.MVVM/Catel.MVVM.Shared/Windows/Interactivity/Behaviors/CommandBehaviorBase.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/Windows/Interactivity/Behaviors/CommandBehaviorBase.cs
@@ -10,7 +10,6 @@ namespace Catel.Windows.Interactivity
 {
     using System.Windows.Input;
     using Catel.Windows.Input;
-    using EventWrappers;
 #if NETFX_CORE
     using global::Windows.UI.Core;
     using global::Windows.UI.Xaml;


### PR DESCRIPTION
Fixes # .

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- DoubleClickToCommand shouldn't contribute in memory leaks (it didn't cause it directly but it can help to avoid it)

Tests not included because they will rely on non-reliable GC behavior.