### PR TITLE
CTL-998 JSON Serialization With Formatted Indents

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -13,5 +13,6 @@
 Daniel Kühner <daniel.kuehner@gmail.com>
 Geert van Horrik <geert@catenalogic.com>
 Mattias Eppler <mattias-eppler@gmx.de>
+Steven Chapman <stev.code@gmail.com>
 Trezamere <trezamere@outlook.com>
 Wojciech Gomoła <szogun1987@gmail.com>

--- a/doc/history.txt
+++ b/doc/history.txt
@@ -67,6 +67,7 @@ Added/fixed:
 (+) CTL-907  Support classes that implement Parse(string, IFormatProvider) and ToString(IFormatProvider) in the serializers 
 (+) CTL-929  Add Additional {WorkDir} as FileLogListener Keyword
 (+) CTL-953  Create pool manager to re-use objects in a pool (e.g. memory streams in serialization)
+(+) CTL-998  JSON Serializer cannot serialize with formatted indents
 (+) CTL-1011 Implement IUIVisualizerService for UWP and removed non-async methods for WPF
 (+) CTL-1015 Implement IOpenFileService for UWP and make all methods async (also for WPF)
 (+) CTL-1016 Implement ISelectDirectoryService for UWP and make all methods async (also for WPF)

--- a/src/Catel.Serialization.Json/Catel.Serialization.Json.Shared/Runtime/Serialization/JsonSerialization/JsonSerializationConfiguration.cs
+++ b/src/Catel.Serialization.Json/Catel.Serialization.Json.Shared/Runtime/Serialization/JsonSerialization/JsonSerializationConfiguration.cs
@@ -46,5 +46,13 @@ namespace Catel.Runtime.Serialization.Json
         /// The date time zone handling.
         /// </value>
         public DateTimeZoneHandling DateTimeZoneHandling { get; set; }
+
+        /// <summary>
+        /// Gets or sets the json formatting.
+        /// </summary>
+        /// <value>
+        /// The json formatting.
+        /// </value>
+        public Formatting Formatting { get; set; }
     }
 }

--- a/src/Catel.Serialization.Json/Catel.Serialization.Json.Shared/Runtime/Serialization/JsonSerialization/JsonSerializer.cs
+++ b/src/Catel.Serialization.Json/Catel.Serialization.Json.Shared/Runtime/Serialization/JsonSerialization/JsonSerializer.cs
@@ -815,6 +815,7 @@ namespace Catel.Runtime.Serialization.Json
             var dateTimeKind = DateTimeKind.Unspecified;
             var dateParseHandling = DateParseHandling.None;
             var dateTimeZoneHandling = DateTimeZoneHandling.Unspecified;
+            var formatting = Formatting.None;
 
             var jsonConfiguration = configuration as JsonSerializationConfiguration;
             if (jsonConfiguration != null)
@@ -823,6 +824,7 @@ namespace Catel.Runtime.Serialization.Json
                 dateTimeKind = jsonConfiguration.DateTimeKind;
                 dateParseHandling = jsonConfiguration.DateParseHandling;
                 dateTimeZoneHandling = jsonConfiguration.DateTimeZoneHandling;
+                formatting = jsonConfiguration.Formatting;
             }
 
             switch (contextMode)
@@ -884,6 +886,7 @@ namespace Catel.Runtime.Serialization.Json
             {
                 jsonWriter.Culture = configuration.Culture;
                 jsonWriter.DateTimeZoneHandling = dateTimeZoneHandling;
+                jsonWriter.Formatting = formatting;
             }
 
             return GetContext(model, modelType, jsonReader, jsonWriter, contextMode, null, null, configuration);

--- a/src/Catel.Test/Catel.Test.Shared/Runtime/Serialization/JsonSerialization/JsonSerializationFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Runtime/Serialization/JsonSerialization/JsonSerializationFacts.cs
@@ -171,6 +171,31 @@ namespace Catel.Test.Runtime.Serialization
                 Assert.IsFalse(json.Contains("Excluded"));
             }
 
+            [TestCase]
+            public void CorrectlySerializesObjectsWithFormattedIndents()
+            {
+                var serviceLocator = ServiceLocator.Default;
+                var serializer = serviceLocator.ResolveType<IJsonSerializer>();
+
+                var model = new CustomJsonSerializationModel
+                {
+                    FirstName = "Geert"
+                };
+
+                var configuration = new JsonSerializationConfiguration
+                {
+                    Formatting = Newtonsoft.Json.Formatting.Indented
+                };
+
+                var clonedModel = SerializationTestHelper.SerializeAndDeserialize(model, serializer, configuration);
+
+                // Note: yes, the *model* is serialized, the *clonedModel* is deserialized
+                Assert.IsTrue(model.IsCustomSerialized);
+                Assert.IsTrue(clonedModel.IsCustomDeserialized);
+
+                Assert.AreEqual(model.FirstName, clonedModel.FirstName);
+            }
+
             //[TestCase]
             //public void CorrectlySerializesToJsonStringWithInvariantCulture()
             //{


### PR DESCRIPTION
Fixes #1001 (CTL-998).

### Checklist

- [x ] I have included examples or tests
- [x ] I have updated the change log
- [x ] I am listed in the CONTRIBUTORS file
- [x ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- This commit adds an optional property to the json configuration that
allows the serialized json string to be formatted with indents.

