### PR TITLE
(*) #123 CTL-1007 Command CanExecute listeners are referenced with weak references

### DIFF
--- a/doc/history.txt
+++ b/doc/history.txt
@@ -82,6 +82,7 @@ Added/fixed:
 (*) CTL-941  Update to json.net 9.x
 (*) CTL-948  Allow setting the status in IPleaseWaitServiceExtensions.PushInScope
 (*) CTL-988  Allow view models without model injection to stay alive on DataContext changes
+(*) #123     Command CanExecute listeners are referenced with weak references
 (*) #807     Exceptions in TaskCommand are now longer swallowed by default. Pre 5.0 behavior can be mimmicked by setting
              the TaskCommand.SwallowExceptions property to true
 (*) #901     Clean up FrameworkElement and DependencyObject extension methods

--- a/src/Catel.Core/Catel.Core.Shared/Catel.Core.Shared.projitems
+++ b/src/Catel.Core/Catel.Core.Shared/Catel.Core.Shared.projitems
@@ -421,9 +421,11 @@
     <Compile Include="$(MSBuildThisFileDirectory)WeakReferences\Interfaces\IExecuteWithObject.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WeakReferences\Interfaces\IWeakAction.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WeakReferences\Interfaces\IWeakEventListener.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)WeakReferences\Interfaces\IWeakFunc.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WeakReferences\Interfaces\IWeakReference.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WeakReferences\WeakAction.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WeakReferences\WeakEventListener.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)WeakReferences\WeakFunc.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)ComponentModel\DataAnnotations\" />

--- a/src/Catel.Core/Catel.Core.Shared/WeakReferences/Interfaces/IExecute.cs
+++ b/src/Catel.Core/Catel.Core.Shared/WeakReferences/Interfaces/IExecute.cs
@@ -18,4 +18,17 @@ namespace Catel
         /// <returns><c>true</c> if the action is executed successfully; otherwise <c>false</c>.</returns>
         bool Execute();
     }
+
+    /// <summary>
+    /// Interface defining a method to execute the object. This allows several classes to be executed
+    /// without the know-how of the types itself, as long as they implement this interface.
+    /// </summary>
+    public interface IExecute<TResult>
+    {
+        /// <summary>
+        /// Executes the object without any parameters.
+        /// </summary>
+        /// <returns><c>true</c> if the action is executed successfully; otherwise <c>false</c>.</returns>
+        bool Execute(out TResult result);
+    }
 }

--- a/src/Catel.Core/Catel.Core.Shared/WeakReferences/Interfaces/IExecuteWithObject.cs
+++ b/src/Catel.Core/Catel.Core.Shared/WeakReferences/Interfaces/IExecuteWithObject.cs
@@ -22,4 +22,22 @@ namespace Catel
         /// <returns><c>true</c> if the action is executed successfully; otherwise <c>false</c>.</returns>
         bool ExecuteWithObject(object parameter);
     }
+
+    /// <summary>
+    /// Interface defining a method accepting an object parameter. This allows the execution
+    /// of generic objects in a non-generic way.
+    /// </summary>
+    public interface IExecuteWithObject<TResult>
+    {
+        /// <summary>
+        /// Executes the object with the object parameter.
+        /// <para />
+        /// The class implementing this interface is responsible for casting the <paramref name="parameter"/>
+        /// to the right type and to determine whether <c>null</c> is allowed as parameter.
+        /// </summary>
+        /// <param name="parameter">The parameter.</param>
+        /// <param name="result">The result</param>
+        /// <returns><c>true</c> if the action is executed successfully; otherwise <c>false</c>.</returns>
+        bool ExecuteWithObject(object parameter, out TResult result);
+    }
 }

--- a/src/Catel.Core/Catel.Core.Shared/WeakReferences/Interfaces/IWeakFunc.cs
+++ b/src/Catel.Core/Catel.Core.Shared/WeakReferences/Interfaces/IWeakFunc.cs
@@ -1,0 +1,47 @@
+﻿namespace Catel
+{
+    using System;
+
+    /// <summary>
+    /// A weak func which allows the invocation of a command in a weak manner. This way, actions will not cause
+    /// memory leaks.
+    /// </summary>
+    public interface IWeakFunc<TResult> : IWeakReference, IExecute<TResult>
+    {
+        /// <summary>
+        /// Gets the name of the method that should be executed.
+        /// </summary>
+        /// <value>The method name.</value>
+        string MethodName { get; }
+
+        /// <summary>
+        /// Gets the actual delegate to invoke.
+        /// </summary>
+        /// <value>The method name.</value>
+        /// <remarks>
+        /// This property is only introduced to allow action comparison on WinRT. Do not try to use this method by yourself.
+        /// </remarks>
+        Delegate Action { get; }
+    }
+    /// <summary>
+    /// A weak func which allows the invocation of a command in a weak manner. This way, actions will not cause
+    /// memory leaks.
+    /// </summary>
+    public interface IWeakFunc<TParameter, TResult> : IWeakReference, IExecuteWithObject<TResult>
+    {
+        /// <summary>
+        /// Gets the name of the method that should be executed.
+        /// </summary>
+        /// <value>The method name.</value>
+        string MethodName { get; }
+
+        /// <summary>
+        /// Gets the actual delegate to invoke.
+        /// </summary>
+        /// <value>The method name.</value>
+        /// <remarks>
+        /// This property is only introduced to allow action comparison on WinRT. Do not try to use this method by yourself.
+        /// </remarks>
+        Delegate Action { get; }
+    }
+}

--- a/src/Catel.Core/Catel.Core.Shared/WeakReferences/Interfaces/IWeakFunc.cs
+++ b/src/Catel.Core/Catel.Core.Shared/WeakReferences/Interfaces/IWeakFunc.cs
@@ -1,4 +1,10 @@
-﻿namespace Catel
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IWeakFunc.cs" company="Catel development team">
+//   Copyright (c) 2008 - 2017 Catel development team. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Catel
 {
     using System;
 

--- a/src/Catel.Core/Catel.Core.Shared/WeakReferences/WeakFunc.cs
+++ b/src/Catel.Core/Catel.Core.Shared/WeakReferences/WeakFunc.cs
@@ -1,0 +1,207 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="WeakFunc.cs" company="Catel development team">
+//   Copyright (c) 2008 - 2017 Catel development team. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Catel
+{
+    using System;
+
+    using Catel.Logging;
+    using Catel.Reflection;
+
+    /// <summary>
+    /// A weak func which allows the invocation of a command in a weak manner. This way, actions will not cause
+    /// memory leaks.
+    /// </summary>
+    public class WeakFunc<TResult> : WeakActionBase, IWeakFunc<TResult>
+    {
+        /// <summary>
+        /// Open instance action which allows the creation of an instance method without an actual reference
+        /// to the target.
+        /// </summary>
+        public delegate TResult OpenInstanceAction<TTarget>(TTarget @this);
+
+        /// <summary>
+        /// The log.
+        /// </summary>
+        private static readonly ILog Log = LogManager.GetCurrentClassLogger();
+
+        /// <summary>
+        /// The action that must be invoked on the action.
+        /// </summary>
+        private Delegate _action;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WeakAction"/> class.
+        /// </summary>
+        /// <param name="target">The target.</param>
+        /// <param name="func">The action.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="func"/> is <c>null</c>.</exception>
+        /// <exception cref="NotSupportedException">The <paramref name="func"/> is an anonymous delegate.</exception>
+        public WeakFunc(object target, Func<TResult> func)
+            : base(target)
+        {
+            Argument.IsNotNull("action", func);
+
+            var methodInfo = func.GetMethodInfoEx();
+            MethodName = methodInfo.ToString();
+
+            if (MethodName.Contains("_AnonymousDelegate>"))
+            {
+                throw Log.ErrorAndCreateException<NotSupportedException>("Anonymous delegates are not supported because they are located in a private class");
+            }
+
+            var targetType = target?.GetType() ?? typeof(object);
+            var delegateType = typeof(OpenInstanceAction<>).MakeGenericType(typeof(TResult), targetType);
+
+            _action = DelegateHelper.CreateDelegate(delegateType, methodInfo);
+        }
+
+        /// <summary>
+        /// Gets the name of the method that should be executed.
+        /// </summary>
+        /// <value>The method name.</value>
+        public string MethodName { get; private set; }
+
+        /// <summary>
+        /// Gets the actual delegate to invoke.
+        /// </summary>
+        /// <value>The method name.</value>
+        /// <remarks>
+        /// This property is only introduced to allow action comparison on WinRT. Do not try to use this method by yourself.
+        /// </remarks>
+        public Delegate Action { get { return _action; } }
+
+        /// <summary>
+        /// Executes the action. This only happens if the action's target is still alive.
+        /// </summary>
+        /// <param name="result"></param>
+        /// <returns>
+        /// <c>true</c> if the action is executed successfully; otherwise <c>false</c>.
+        /// </returns>
+        public bool Execute(out TResult result)
+        {
+            result = default(TResult);
+            if (_action != null)
+            {
+                if (IsTargetAlive)
+                {
+                    result = (TResult)_action.DynamicInvoke(Target);
+                    return true;
+                }
+
+                Log.Debug("Target for '{0}' is no longer alive, weak event being garbage collected", MethodName);
+
+                _action = null;
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// A generic weak func which allows the invocation of a command in a weak manner. This way, funcs will not 
+    /// cause memory leaks.
+    /// </summary>
+    public class WeakFunc<TParameter, TResult> : WeakActionBase, IWeakFunc<TParameter, TResult>
+    {
+        /// <summary>
+        /// Open instance action which allows the creation of an instance method without an actual reference
+        /// to the target.
+        /// </summary>
+        public delegate TResult OpenInstanceGenericAction<TTarget>(TTarget @this, TParameter parameter);
+
+        /// <summary>
+        /// The log.
+        /// </summary>
+        private static readonly ILog Log = LogManager.GetCurrentClassLogger();
+
+        /// <summary>
+        /// The action that must be invoked on the action.
+        /// </summary>
+        private Delegate _action;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WeakAction"/> class.
+        /// </summary>
+        /// <param name="target">The target.</param>
+        /// <param name="func">The function.</param> 
+        /// <exception cref="ArgumentNullException">The <paramref name="func"/> is <c>null</c>.</exception>
+        /// <exception cref="NotSupportedException">The <paramref name="func"/> is an anonymous delegate.</exception>
+        public WeakFunc(object target, Func<TParameter, TResult> func)
+            : base(target)
+        {
+            Argument.IsNotNull("func", func);
+
+            var methodInfo = func.GetMethodInfoEx();
+            MethodName = methodInfo.ToString();
+
+            if (MethodName.Contains("_AnonymousDelegate>"))
+            {
+                throw Log.ErrorAndCreateException<NotSupportedException>("Anonymous delegates are not supported because they are located in a private class");
+            }
+
+            var targetType = target?.GetType() ?? typeof(object);
+            var delegateType = typeof(OpenInstanceGenericAction<>).MakeGenericType(typeof(TParameter), typeof(TResult), targetType);
+
+            _action = DelegateHelper.CreateDelegate(delegateType, methodInfo);
+        }
+
+        /// <summary>
+        /// Gets the name of the method that should be executed.
+        /// </summary>
+        /// <value>The method name.</value>
+        public string MethodName { get; private set; }
+
+        /// <summary>
+        /// Gets the actual delegate to invoke.
+        /// </summary>
+        /// <value>The method name.</value>
+        /// <remarks>
+        /// This property is only introduced to allow action comparison on WinRT. Do not try to use this method by yourself.
+        /// </remarks>
+        public Delegate Action { get { return _action; } }
+
+        /// <summary>
+        /// Executes the action. This only happens if the action's target is still alive.
+        /// </summary>
+        /// <param name="parameter">The parameter.</param>
+        /// <param name="result">The result</param>
+        public bool Execute(TParameter parameter, out TResult result)
+        {
+            result = default(TResult);
+            if (_action != null)
+            {
+                if (IsTargetAlive)
+                {
+                    result = (TResult)_action.DynamicInvoke(Target, parameter);
+                    return true;
+                }
+
+                Log.Debug("Target for '{0}' is no longer alive, weak event being garbage collected", MethodName);
+
+                _action = null;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Executes the object with the object parameter.
+        /// <para/>
+        /// The class implementing this interface is responsible for casting the <paramref name="parameter"/>
+        /// to the right type and to determine whether <c>null</c> is allowed as parameter.
+        /// </summary>
+        /// <param name="parameter">The parameter.</param>
+        /// <param name="result">The result</param>
+        /// <returns>
+        /// <c>true</c> if the action is executed successfully; otherwise <c>false</c>.
+        /// </returns>
+        bool IExecuteWithObject<TResult>.ExecuteWithObject(object parameter, out TResult result)
+        {
+            return Execute((TParameter)parameter, out result);
+        }
+    }
+}

--- a/src/Catel.Test/Catel.Test.Shared/Catel.Test.Shared.projitems
+++ b/src/Catel.Test/Catel.Test.Shared/Catel.Test.Shared.projitems
@@ -231,6 +231,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Threading\TaskHelperFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WeakReferences\WeakActionTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WeakReferences\WeakEventListenerFacts.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)WeakReferences\WeakFuncTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows\Helpers\ResourceHelperFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows\Input\InputGestureFacts.cs" />
   </ItemGroup>

--- a/src/Catel.Test/Catel.Test.Shared/Catel.Test.Shared.projitems
+++ b/src/Catel.Test/Catel.Test.Shared/Catel.Test.Shared.projitems
@@ -231,7 +231,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Threading\TaskHelperFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WeakReferences\WeakActionTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WeakReferences\WeakEventListenerFacts.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)WeakReferences\WeakFuncTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)WeakReferences\WeakFuncFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows\Helpers\ResourceHelperFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows\Input\InputGestureFacts.cs" />
   </ItemGroup>

--- a/src/Catel.Test/Catel.Test.Shared/WeakReferences/WeakFuncFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/WeakReferences/WeakFuncFacts.cs
@@ -1,3 +1,9 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="WeakFuncFacts.cs" company="Catel development team">
+//   Copyright (c) 2008 - 2017 Catel development team. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
 namespace Catel.Test
 {
     using System;
@@ -5,7 +11,7 @@ namespace Catel.Test
     using NUnit.Framework;
 
     [TestFixture]
-    public class WeakFuncTest
+    public class WeakFuncFacts
     {
         #region Test classes
         public class FuncTarget
@@ -23,25 +29,25 @@ namespace Catel.Test
             #region Methods
             public bool PublicFuncToExecute()
             {
-                this.PublicFuncExecutedCount++;
+                PublicFuncExecutedCount++;
                 return true;
             }
 
             public bool PrivateFuncToExecute()
             {
-                this.PrivateFuncExecutedCount++;
+                PrivateFuncExecutedCount++;
                 return true;
             }
 
             public bool PublicFuncWithParameterToExecute(int parameter)
             {
-                this.PublicFuncWithParameterExecutedCount++;
+                PublicFuncWithParameterExecutedCount++;
                 return true;
             }
 
             public bool PrivateFuncWithParameterToExecute(int parameter)
             {
-                this.PrivateFuncWithParameterExecutedCount++;
+                PrivateFuncWithParameterExecutedCount++;
                 return true;
             }
             #endregion

--- a/src/Catel.Test/Catel.Test.Shared/WeakReferences/WeakFuncTest.cs
+++ b/src/Catel.Test/Catel.Test.Shared/WeakReferences/WeakFuncTest.cs
@@ -1,0 +1,122 @@
+namespace Catel.Test
+{
+    using System;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class WeakFuncTest
+    {
+        #region Test classes
+        public class FuncTarget
+        {
+            #region Properties
+            public int PublicFuncExecutedCount { get; private set; }
+
+            public int PrivateFuncExecutedCount { get; private set; }
+
+            public int PublicFuncWithParameterExecutedCount { get; private set; }
+
+            public int PrivateFuncWithParameterExecutedCount { get; private set; }
+            #endregion
+
+            #region Methods
+            public bool PublicFuncToExecute()
+            {
+                this.PublicFuncExecutedCount++;
+                return true;
+            }
+
+            public bool PrivateFuncToExecute()
+            {
+                this.PrivateFuncExecutedCount++;
+                return true;
+            }
+
+            public bool PublicFuncWithParameterToExecute(int parameter)
+            {
+                this.PublicFuncWithParameterExecutedCount++;
+                return true;
+            }
+
+            public bool PrivateFuncWithParameterToExecute(int parameter)
+            {
+                this.PrivateFuncWithParameterExecutedCount++;
+                return true;
+            }
+            #endregion
+        }
+        #endregion
+
+        #region Methods
+        [TestCase]
+        public void MemoryLeakFreeWithNoInvocation()
+        {
+            var target = new FuncTarget();
+            var weakAction = new WeakFunc<bool>(target, target.PublicFuncToExecute);
+
+            target = null;
+            GC.Collect();
+
+            Assert.IsFalse(weakAction.IsTargetAlive);
+        }
+
+        [TestCase]
+        public void NonGeneric_PublicMethod()
+        {
+            var target = new FuncTarget();
+            var weakFunc = new WeakFunc<bool>(target, target.PublicFuncToExecute);
+
+            bool result;
+            Assert.IsTrue(weakFunc.Execute(out result));
+
+            Assert.AreEqual(1, target.PublicFuncExecutedCount);
+
+            target = null;
+            GC.Collect();
+
+            Assert.IsFalse(weakFunc.IsTargetAlive);
+        }
+
+        [TestCase]
+        public void NonGeneric_AnonymousDelegate()
+        {
+            ExceptionTester.CallMethodAndExpectException<NotSupportedException>(() => new WeakFunc<bool>(null, () => true));
+        }
+
+        [TestCase]
+        public void Generic_PublicMethod()
+        {
+            var target = new FuncTarget();
+            var weakFunc = new WeakFunc<int, bool>(target, target.PublicFuncWithParameterToExecute);
+
+            bool result;
+            Assert.IsTrue(weakFunc.Execute(1, out result));
+
+            Assert.AreEqual(1, target.PublicFuncWithParameterExecutedCount);
+
+            target = null;
+            GC.Collect();
+
+            Assert.IsFalse(weakFunc.IsTargetAlive);
+        }
+
+        [TestCase]
+        public void Generic_AnonymousDelegate()
+        {
+            var count = 0;
+
+            ExceptionTester.CallMethodAndExpectException<NotSupportedException>(
+                () => new WeakFunc<int, bool>(
+                    null,
+                    i =>
+                        {
+                            count = i;
+                            return true;
+                        }));
+
+            Assert.AreEqual(0, count);
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
Fixes #123 CTL-1007.

### Changes proposed in this pull request:

- Command CanExecute listeners are referenced with weak references