### PR TITLE
(x) #815 CTL-822 MessageMediator registers new recipients after previous registration of the same type of recipient were garbage collected

### DIFF
--- a/doc/history.txt
+++ b/doc/history.txt
@@ -98,6 +98,8 @@ Added/fixed:
 (*) #1050    Replace ISavableModel.SerializationMode with ISerializer and remove some overloads
 (*) #1052    Move property value change notifications wrappers (for child objects & collections) from ModelBase 
              to ChildAwareModelBase 
+(x) #815     MessageMediator registers new recipients after previous registration of same type of recipient were 
+	     garbage collected
 (x) CTL-899  Navigation in WPF is not working when using custom frame
 (x) CTL-906  Clear current navigation context when (re)navigating to the same view in WPF
 (x) CTL-910  Introduce special lock for null keys in CacheStorage to prevent ArgumentNullException

--- a/src/Catel.Test/Catel.Test.Shared/Messaging/MessageMediatorFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Messaging/MessageMediatorFacts.cs
@@ -387,6 +387,36 @@ namespace Catel.Test.Messaging
             #endregion
         }
         #endregion
+
+    
+        [TestFixture]
+        public class TheIsRegisteredMethod
+        {
+ 
+            [Test]
+            public void ReturnsTrueAfterRegistration()
+            {
+                var recipient = new MessageRecipient();
+                var messageMediator = new MessageMediator();
+                messageMediator.Register<string>(recipient, recipient.OnMessage);
+                Assert.IsTrue(messageMediator.IsRegistered<string>(recipient, recipient.OnMessage));
+            }
+
+            [Test]
+            public void ReturnsFalseAfterGarbageCollected()
+            {
+                var recipient = new MessageRecipient();
+                var messageMediator = new MessageMediator();
+                messageMediator.Register<string>(recipient, recipient.OnMessage);
+
+                recipient = null;
+
+                GC.Collect();
+
+                recipient = new MessageRecipient();
+                Assert.IsFalse(messageMediator.IsRegistered<string>(recipient, recipient.OnMessage));
+            }
+        }
     }
 
     public class Message

--- a/src/Catel.Test/Catel.Test.Shared/Messaging/MessageMediatorHelperFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Messaging/MessageMediatorHelperFacts.cs
@@ -8,6 +8,7 @@ namespace Catel.Test.Messaging
 {
     using System;
     using Catel.Messaging;
+    using Catel.Reflection;
     using NUnit.Framework;
 
     public class MessageMediatorHelperFacts


### PR DESCRIPTION
Fixes #815.

### Changes proposed in this pull request:

- MessageMediator registers new recipients after previous registration of the same type of recipient were garbage collected