### PR TITLE
(x) #892 ModelBase CancelEdit puts Model into dirty state

### DIFF
--- a/doc/history.txt
+++ b/doc/history.txt
@@ -109,6 +109,7 @@ Added/fixed:
 (*)          Improve ShowWindowAsync implementation at UIVisualizerService
 (x) #815     MessageMediator registers new recipients after previous registration of same type of recipient were 
              garbage collected
+(x) #892     ModelBase CancelEdit puts Model into dirty state
 (x) CTL-899  Navigation in WPF is not working when using custom frame
 (x) CTL-906  Clear current navigation context when (re)navigating to the same view in WPF
 (x) CTL-910  Introduce special lock for null keys in CacheStorage to prevent ArgumentNullException

--- a/src/Catel.Core/Catel.Core.Shared/Data/ModelBase.editableobject.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Data/ModelBase.editableobject.cs
@@ -308,25 +308,32 @@ namespace Catel.Data
         /// </summary>
         void IEditableObject.EndEdit()
         {
-            if (_backup == null)
+            try
             {
-                Log.Debug("IEditableObject is not in edit state");
-                return;
+                if (_backup == null)
+                {
+                    Log.Debug("IEditableObject is not in edit state");
+                    return;
+                }
+
+                var eventArgs = new EndEditEventArgs(this);
+                _endEditingEvent.SafeInvoke(this, eventArgs);
+                OnEndEdit(eventArgs);
+
+                if (eventArgs.Cancel)
+                {
+                    Log.Info("IEditableObject.EndEdit is canceled by the event args");
+                    return;
+                }
+
+                Log.Debug("IEditableObject.EndEdit");
+
+                _backup = null;
             }
-
-            var eventArgs = new EndEditEventArgs(this);
-            _endEditingEvent.SafeInvoke(this, eventArgs);
-            OnEndEdit(eventArgs);
-
-            if (eventArgs.Cancel)
+            finally
             {
-                Log.Info("IEditableObject.EndEdit is canceled by the event args");
-                return;
+                IsDirty = false;
             }
-
-            Log.Debug("IEditableObject.EndEdit");
-
-            _backup = null;
         }
     }
 }

--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/ViewModels/ViewModelBase.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/ViewModels/ViewModelBase.cs
@@ -988,6 +988,12 @@ namespace Catel.MVVM
                                             string.Join(", ", propertiesToSet), string.Join(", ", valuesToSet));
                                     }
 
+                                    
+                                    if (modelInfo.SupportIEditableObject)
+                                    {
+                                        (model as IEditableObject)?.BeginEdit();
+                                    }
+
                                     for (var index = 0; index < propertiesToSet.Length && index < valuesToSet.Length; index++)
                                     {
                                         try
@@ -1411,10 +1417,19 @@ namespace Catel.MVVM
 
             lock (_modelLock)
             {
+                bool isDirty = false;
+
                 foreach (var modelKeyValuePair in _modelObjects)
                 {
                     UninitializeModelInternal(modelKeyValuePair.Key, modelKeyValuePair.Value, ModelCleanUpMode.CancelEdit);
+                    var model = modelKeyValuePair.Value as IModel;
+                    if (model != null)
+                    {
+                        isDirty |= model.IsDirty;
+                    }
                 }
+
+                IsDirty = isDirty;
             }
 
             Log.Info("Canceled view model '{0}'", GetType());
@@ -1477,10 +1492,19 @@ namespace Catel.MVVM
             {
                 lock (_modelLock)
                 {
+                    bool isDirty = false;
                     foreach (KeyValuePair<string, object> modelKeyValuePair in _modelObjects)
                     {
                         UninitializeModelInternal(modelKeyValuePair.Key, modelKeyValuePair.Value, ModelCleanUpMode.EndEdit);
+
+                        var model = modelKeyValuePair.Value as IModel;
+                        if (model != null)
+                        {
+                            isDirty |= model.IsDirty;
+                        }
                     }
+
+                    IsDirty = isDirty;
                 }
 
                 await SavedAsync.SafeInvokeAsync(this);

--- a/src/Catel.Test/Catel.Test.Shared/MVVM/ViewModels/ViewModelBaseFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/MVVM/ViewModels/ViewModelBaseFacts.cs
@@ -11,9 +11,11 @@ namespace Catel.Test.MVVM.ViewModels
     using System.Threading;
     using System.Threading.Tasks;
     using Auditing;
+    using Catel.Data;
     using Catel.MVVM;
     using Catel.MVVM.Auditing;
     using NUnit.Framework;
+    using TestClasses;
     using TestViewModel = TestClasses.TestViewModel;
 
     [TestFixture]
@@ -233,6 +235,39 @@ namespace Catel.Test.MVVM.ViewModels
             var firstId = flatenSortedIdentifiers[0];
 
             Assert.That(flatenSortedIdentifiers, Is.EquivalentTo(Enumerable.Range(firstId, personsPerThread * threadAmount)));
+        }
+
+        [Test]
+        public async Task SaveViewModelAsync_Sets_Model_State_To_No_Dirty()
+        {
+            var viewModel = new TestViewModelWithMappings(new Person {FirstName = "Name", MiddleName = "MiddleName", LastName = "LastName"});
+
+            await viewModel.SaveViewModelAsync();
+
+            Assert.IsFalse(((IModel)viewModel.Person).IsDirty);
+        }
+
+        [Test]
+        public async Task Update_ViewModelToModel_Property_Sets_Model_Into_Dirty_State()
+        {
+            var viewModel = new TestViewModelWithMappings(new Person { FirstName = "Name", MiddleName = "MiddleName", LastName = "LastName" });
+            await viewModel.SaveViewModelAsync();
+
+            viewModel.FirstNameAsTwoWay = "First Name";
+            Assert.IsTrue(((IModel)viewModel.Person).IsDirty);
+        }
+
+        [Test]
+        public async Task CancelViewModelAsync_Restores_Model_To_Last_Saved_No_Dirty_State()
+        {
+            var viewModel = new TestViewModelWithMappings(new Person { FirstName = "Name", MiddleName = "MiddleName", LastName = "LastName" });
+            await viewModel.SaveViewModelAsync();
+
+            viewModel.FirstNameAsTwoWay = "First Name";
+            Assert.IsTrue(((IModel)viewModel.Person).IsDirty);
+
+            await viewModel.CancelViewModelAsync();
+            Assert.IsFalse(((IModel) viewModel.Person).IsDirty);
         }
     }
 }


### PR DESCRIPTION
Fixes #892.

### Checklist

- [X] I have included examples or tests
- [X] I have updated the change log
- [X] I am listed in the CONTRIBUTORS file
- [X] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Set IsDirty property set to false at EndEdit
- Call BeginEdit of the model (if SupportIEditableObject is true) to create the backup at the exact time before start editing.
- Set IsDity with the combination of the models isDirty property at Cancel Or Save 
