### PR TITLE
(*) #1083 Derived ChildAwareModelBase from ValidatableModelBase instead of ModelBase

### DIFF
--- a/doc/history.txt
+++ b/doc/history.txt
@@ -29,6 +29,7 @@ Added/fixed:
 (*) #1017 Improve performance of ViewToViewModelMappingHelper
 (*) #1068 Minimize allocations using ArrayShim
 (*) #1070 TypeFactory.CreateInstanceWithParameters use the most specialized constructor
+(*) #1083 Derived ChildAwareModelBase from ValidatableModelBase instead of ModelBase
 (*) #1084 Add virtual validation methods to ValidatableModelBase
 
 Roadmap:

--- a/src/Catel.Core/Catel.Core.Shared/Data/ChildAwareModelBase.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Data/ChildAwareModelBase.cs
@@ -20,7 +20,7 @@ namespace Catel.Data
     /// <summary>
     /// Class that is aware of changes of child objects by using the <see cref="ChangeNotificationWrapper"/>.
     /// </summary>
-    public abstract class ChildAwareModelBase : ModelBase
+    public abstract class ChildAwareModelBase : ValidatableModelBase
     {
         /// <summary>
         /// The change notification wrappers for all property values.


### PR DESCRIPTION
Fixes #1083.

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Derived ChildAwareModelBase from ValidatableModelBase instead of ModelBase because the advantage of ChildAwareModelBase lies in the combination with ValidatableModelBase
