### PR TITLE
(*) #1085 Changed ValidatableModelBase.IsValidationSuspended to be virtual

### DIFF
--- a/doc/history.txt
+++ b/doc/history.txt
@@ -31,6 +31,7 @@ Added/fixed:
 (*) #1070 TypeFactory.CreateInstanceWithParameters use the most specialized constructor
 (*) #1083 Derived ChildAwareModelBase from ValidatableModelBase instead of ModelBase
 (*) #1084 Add virtual validation methods to ValidatableModelBase
+(*) #1085 Changed ValidatableModelBase.IsValidationSuspended to be virtual
 
 Roadmap:
 ========

--- a/src/Catel.Core/Catel.Core.Shared/Data/ValidatableModelBase.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Data/ValidatableModelBase.cs
@@ -276,7 +276,7 @@ namespace Catel.Data
         /// <value>
         /// <c>true</c> if validation is suspended; otherwise, <c>false</c>.
         /// </value>
-        protected bool IsValidationSuspended
+        protected virtual bool IsValidationSuspended
         {
             get
             {


### PR DESCRIPTION
Fixes #1085.

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Changed ValidatableModelBase.IsValidationSuspended to be virtual so derived classes can determine for themselves when a model can be validated or not