### PR TITLE
(x) #1093 Fixed Command.Execute does not throw exceptions

### DIFF
--- a/doc/history.txt
+++ b/doc/history.txt
@@ -32,7 +32,7 @@ Added/fixed:
 (*) #1083 Derived ChildAwareModelBase from ValidatableModelBase instead of ModelBase
 (*) #1084 Add virtual validation methods to ValidatableModelBase
 (*) #1085 Changed ValidatableModelBase.IsValidationSuspended to be virtual
-(x) #1093 Fixed Command.Execute does not throw exceptions
+(x) #1093 Fix Command.Execute which was no longer throwing exceptions during execution
 
 Roadmap:
 ========

--- a/doc/history.txt
+++ b/doc/history.txt
@@ -32,6 +32,7 @@ Added/fixed:
 (*) #1083 Derived ChildAwareModelBase from ValidatableModelBase instead of ModelBase
 (*) #1084 Add virtual validation methods to ValidatableModelBase
 (*) #1085 Changed ValidatableModelBase.IsValidationSuspended to be virtual
+(x) #1093 Fixed Command.Execute does not throw exceptions
 
 Roadmap:
 ========

--- a/src/Catel.Core/Catel.Core.Shared/WeakReferences/WeakFunc.cs
+++ b/src/Catel.Core/Catel.Core.Shared/WeakReferences/WeakFunc.cs
@@ -93,11 +93,11 @@ namespace Catel
                     {
                         result = (TResult)_action.DynamicInvoke(Target);
                     }
-                    catch (TargetInvocationException e)
+                    catch (TargetInvocationException ex)
                     {
-                        if (e.InnerException != null)
+                        if (ex.InnerException != null)
                         {
-                            throw e.InnerException;
+                            throw ex.InnerException;
                         }
                     }
 
@@ -192,11 +192,11 @@ namespace Catel
                     {
                         result = (TResult)_action.DynamicInvoke(Target, parameter);
                     }
-                    catch (TargetInvocationException e)
+                    catch (TargetInvocationException ex)
                     {
-                        if (e.InnerException != null)
+                        if (ex.InnerException != null)
                         {
-                            throw e.InnerException;
+                            throw ex.InnerException;
                         }
                     }
 

--- a/src/Catel.Core/Catel.Core.Shared/WeakReferences/WeakFunc.cs
+++ b/src/Catel.Core/Catel.Core.Shared/WeakReferences/WeakFunc.cs
@@ -7,6 +7,7 @@
 namespace Catel
 {
     using System;
+    using System.Reflection;
 
     using Catel.Logging;
     using Catel.Reflection;
@@ -88,7 +89,18 @@ namespace Catel
             {
                 if (IsTargetAlive)
                 {
-                    result = (TResult)_action.DynamicInvoke(Target);
+                    try
+                    {
+                        result = (TResult)_action.DynamicInvoke(Target);
+                    }
+                    catch (TargetInvocationException e)
+                    {
+                        if (e.InnerException != null)
+                        {
+                            throw e.InnerException;
+                        }
+                    }
+
                     return true;
                 }
 
@@ -176,7 +188,18 @@ namespace Catel
             {
                 if (IsTargetAlive)
                 {
-                    result = (TResult)_action.DynamicInvoke(Target, parameter);
+                    try
+                    {
+                        result = (TResult)_action.DynamicInvoke(Target, parameter);
+                    }
+                    catch (TargetInvocationException e)
+                    {
+                        if (e.InnerException != null)
+                        {
+                            throw e.InnerException;
+                        }
+                    }
+
                     return true;
                 }
 

--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Commands/Command.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Commands/Command.cs
@@ -244,7 +244,7 @@ namespace Catel.MVVM
         public void Execute(TExecuteParameter parameter)
         {
 #pragma warning disable 4014
-            ExecuteAsync(parameter, false);
+            ExecuteAsync(parameter, false).Wait();
 #pragma warning restore 4014
         }
 

--- a/src/Catel.Test/Catel.Test.Shared/Catel.Test.Shared.projitems
+++ b/src/Catel.Test/Catel.Test.Shared/Catel.Test.Shared.projitems
@@ -145,6 +145,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)MVVM\Auditing\AuditorTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MVVM\Auditing\TestAuditor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MVVM\Auditing\TestViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)MVVM\Commands\CommandFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MVVM\Commands\CommandManagerExtensionsFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MVVM\Commands\CommandManagerFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MVVM\Commands\CompositeCommandFacts.cs" />

--- a/src/Catel.Test/Catel.Test.Shared/MVVM/Commands/CommandFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/MVVM/Commands/CommandFacts.cs
@@ -1,0 +1,36 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="FastObservableCollectionFacts.cs" company="Catel development team">
+//   Copyright (c) 2008 - 2017 Catel development team. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+
+namespace Catel.Test.MVVM.Commands
+{
+    using System;
+
+    using Catel.MVVM;
+
+    using NUnit.Framework;
+
+    public class CommandFacts
+    {
+        [TestFixture]
+        public class TheExecuteCommand
+        {
+            [Test]
+            public void ExecuteThrowsException()
+            {
+                var command = new Command(() => { throw new Exception(); }, () => true);
+                ExceptionTester.CallMethodAndExpectException<Exception>(() => command.Execute());
+            }
+
+            [Test]
+            public void CanExecuteThrowsException()
+            {
+                var command = new Command(() => { }, () => { throw new Exception(); });
+                ExceptionTester.CallMethodAndExpectException<Exception>(() => command.Execute());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1093.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Catching and rethrowing exceptions of DynamicInvoke called from WeakFunc.Execute
- Awaiting per .Wait() .ExecuteAsync in .Execute so exceptions are not swallowed
