### PR TITLE
(+) #1096 Add mode MixedConsolidate to FastObservableCollection

### DIFF
--- a/doc/history.txt
+++ b/doc/history.txt
@@ -26,6 +26,7 @@ Added/fixed:
 (+) #1077 Add IViewModelLocator.IsCompatible and IViewLocator.IsCompatible to allow multiple views and/or 
     views models to be compatible with multiple view models and/or views
 (+) #1095 Add mode MixedBash to FastObservableCollection
+(+) #1096 Add mode MixedConsolidate to FastObservableCollection
 (*) #953  Cache ToString, ToUpper() and ToLower() calls
 (*) #1017 Improve performance of ViewToViewModelMappingHelper
 (*) #1068 Minimize allocations using ArrayShim

--- a/src/Catel.Core/Catel.Core.Shared/Collections/Interfaces/Enums/SuspensionMode.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Collections/Interfaces/Enums/SuspensionMode.cs
@@ -40,6 +40,12 @@ namespace Catel.Collections
         /// that this raises multiple <see cref="NotifyCollectionChangedAction.Add"/> events and <see cref="NotifyCollectionChangedAction.Remove"/>
         /// events instead of single <see cref="NotifyCollectionChangedAction.Reset"/> event.
         /// </summary>
-        MixedBash
+        MixedBash,
+
+        /// <summary>
+        /// MixedConsolidate mode (combination of Adding and Removing). This behaves the same as <see cref="MixedBash"/>, except
+        /// that this consolidates those add and remove events which annulled each other.
+        /// </summary>
+        MixedConsolidate
     }
 }

--- a/src/Catel.MVVM/Catel.MVVM.Shared/Collections/EventArgs/NotifyRangedCollectionChangedEventArgs.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/Collections/EventArgs/NotifyRangedCollectionChangedEventArgs.cs
@@ -10,11 +10,8 @@ namespace Catel.Collections
     using System.Collections;
     using System.Collections.Generic;
     using System.Collections.Specialized;
-    using System.Linq;
 
-    using Catel.Collections.Extensions;
-
-    /// <summary>
+  /// <summary>
     /// The ranged notify collection changed event args.
     /// </summary>
     public class NotifyRangedCollectionChangedEventArgs : NotifyCollectionChangedEventArgs

--- a/src/Catel.MVVM/Catel.MVVM.Shared/Collections/EventArgs/NotifyRangedCollectionChangedEventArgs.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/Collections/EventArgs/NotifyRangedCollectionChangedEventArgs.cs
@@ -10,6 +10,9 @@ namespace Catel.Collections
     using System.Collections;
     using System.Collections.Generic;
     using System.Collections.Specialized;
+    using System.Linq;
+
+    using Catel.Collections.Extensions;
 
     /// <summary>
     /// The ranged notify collection changed event args.
@@ -151,5 +154,5 @@ namespace Catel.Collections
             }
         }
         #endregion
-    }
+  }
 }

--- a/src/Catel.MVVM/Catel.MVVM.Shared/Collections/Extensions/SuspensionContextExtensions.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/Collections/Extensions/SuspensionContextExtensions.cs
@@ -4,138 +4,232 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace Catel.Collections
+
+namespace Catel.Collections.Extensions
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Collections.Specialized;
+  using System;
+  using System.Collections.Generic;
+  using System.Collections.Specialized;
+  using System.Linq;
+
+  /// <summary>
+  /// The suspension context extensions.
+  /// </summary>
+  internal static class SuspensionContextExtensions
+  {
+    #region Methods
+    /// <summary>
+    /// The create event args list.
+    /// </summary>
+    /// <param name="suspensionContext">The suspension context.</param>
+    /// <typeparam name="T">The type of collection item.</typeparam>
+    /// <returns>The <see cref="ICollection{NotifyRangedCollectionChangedEventArgs}"/>.</returns>
+    public static ICollection<NotifyRangedCollectionChangedEventArgs> CreateEventArgsList<T>(this SuspensionContext<T> suspensionContext)
+    {
+      // No suspension context is the same as None mode
+      var mode = suspensionContext?.Mode ?? SuspensionMode.None;
+
+      // Fast return for no items in not None modes
+      // ReSharper disable once PossibleNullReferenceException
+      if (mode != SuspensionMode.None && suspensionContext.ChangedItems.Count == 0)
+      {
+        return new NotifyRangedCollectionChangedEventArgs[] { };
+      }
+
+      // Determine creation depending on mode
+      ICollection<NotifyRangedCollectionChangedEventArgs> eventArgsList = new List<NotifyRangedCollectionChangedEventArgs>();
+      switch (mode)
+      {
+        case SuspensionMode.None:
+          {
+            eventArgsList.Add(new NotifyRangedCollectionChangedEventArgs());
+            break;
+          }
+
+        case SuspensionMode.Adding:
+        case SuspensionMode.Removing:
+          {
+            // ReSharper disable once PossibleNullReferenceException
+            eventArgsList.Add(new NotifyRangedCollectionChangedEventArgs(suspensionContext.ChangedItems, suspensionContext.ChangedItemIndices, mode));
+            break;
+          }
+
+        case SuspensionMode.Mixed:
+          {
+            // ReSharper disable once PossibleNullReferenceException
+            eventArgsList.Add(new NotifyRangedCollectionChangedEventArgs(suspensionContext.ChangedItems, suspensionContext.ChangedItemIndices, suspensionContext.MixedActions));
+            break;
+          }
+
+        case SuspensionMode.MixedBash:
+          {
+            eventArgsList = suspensionContext.CreateMixedBashEventArgsList();
+            break;
+          }
+
+        case SuspensionMode.MixedConsolidate:
+          {
+            eventArgsList = suspensionContext.CreateMixedConsolidateEventArgsList();
+            break;
+          }
+
+        default:
+          {
+            // ReSharper disable once LocalizableElement
+            throw new ArgumentOutOfRangeException(nameof(mode), $"The suspension mode '{mode}' is unhandled.");
+          }
+      }
+
+      return eventArgsList;
+    }
 
     /// <summary>
-    /// The suspension context extensions.
+    /// The create mixed bash event args list.
     /// </summary>
-    internal static class SuspensionContextExtensions
+    /// <param name="suspensionContext">The suspension context.</param>
+    /// <typeparam name="T">The type of collection item.</typeparam>
+    /// <returns>The <see cref="ICollection{NotifyRangedCollectionChangedEventArgs}"/>.</returns>
+    public static ICollection<NotifyRangedCollectionChangedEventArgs> CreateMixedBashEventArgsList<T>(this SuspensionContext<T> suspensionContext)
     {
-        #region Methods
-        /// <summary>
-        /// The create event args list.
-        /// </summary>
-        /// <param name="suspensionContext">The suspension context.</param>
-        /// <typeparam name="T">The type of collection item.</typeparam>
-        /// <returns>The <see cref="ICollection{NotifyRangedCollectionChangedEventArgs}"/>.</returns>
-        public static ICollection<NotifyRangedCollectionChangedEventArgs> CreateEventArgsList<T>(this SuspensionContext<T> suspensionContext)
-        {
-            // No suspension context is the same as None mode
-            var mode = suspensionContext?.Mode ?? SuspensionMode.None;
+      Argument.IsNotNull(nameof(suspensionContext), suspensionContext);
+      Argument.IsValid(nameof(suspensionContext.Mode), suspensionContext.Mode, mode => mode == SuspensionMode.MixedBash);
 
-            // Fast return for no items in not None modes
-            // ReSharper disable once PossibleNullReferenceException
-            if (mode != SuspensionMode.None && suspensionContext.ChangedItems.Count == 0)
-            {
-                return new NotifyRangedCollectionChangedEventArgs[] { };
-            }
-
-            // Determine creation depending on mode
-            ICollection<NotifyRangedCollectionChangedEventArgs> eventArgsList = new List<NotifyRangedCollectionChangedEventArgs>();
-            switch (mode)
-            {
-                case SuspensionMode.None:
-                    {
-                        eventArgsList.Add(new NotifyRangedCollectionChangedEventArgs());
-                        break;
-                    }
-
-                case SuspensionMode.Adding:
-                case SuspensionMode.Removing:
-                    {
-                        // ReSharper disable once PossibleNullReferenceException
-                        eventArgsList.Add(new NotifyRangedCollectionChangedEventArgs(suspensionContext.ChangedItems, suspensionContext.ChangedItemIndices, mode));
-                        break;
-                    }
-
-                case SuspensionMode.Mixed:
-                    {
-                        // ReSharper disable once PossibleNullReferenceException
-                        eventArgsList.Add(new NotifyRangedCollectionChangedEventArgs(suspensionContext.ChangedItems, suspensionContext.ChangedItemIndices, suspensionContext.MixedActions));
-                        break;
-                    }
-
-                case SuspensionMode.MixedBash:
-                    {
-                        eventArgsList = suspensionContext.CreateMixedBashEventArgsList();
-                        break;
-                    }
-
-                default:
-                    {
-                        // ReSharper disable once LocalizableElement
-                        throw new ArgumentOutOfRangeException(nameof(mode), $"The suspension mode '{mode}' is unhandled.");
-                    }
-            }
-
-            return eventArgsList;
-        }
-
-        /// <summary>
-        /// The is mixed mode.
-        /// </summary>
-        /// <param name="suspensionContext">The suspension context.</param>
-        /// <typeparam name="T">The type of collection item.</typeparam>
-        /// <returns><c>True</c> if <see cref="SuspensionMode"/> is one of the mixed modes; otherwise, <c>false</c>.</returns>
-        public static bool IsMixedMode<T>(this SuspensionContext<T> suspensionContext)
-        {
-            Argument.IsNotNull(nameof(suspensionContext), suspensionContext);
-
-            return suspensionContext.Mode.IsMixedMode();
-        }
-
-        /// <summary>
-        /// The create mixed bash event args list.
-        /// </summary>
-        /// <param name="suspensionContext">The suspension context.</param>
-        /// <typeparam name="T">The type of collection item.</typeparam>
-        /// <returns>The <see cref="ICollection{NotifyRangedCollectionChangedEventArgs}"/>.</returns>
-        private static ICollection<NotifyRangedCollectionChangedEventArgs> CreateMixedBashEventArgsList<T>(this SuspensionContext<T> suspensionContext)
-        {
-            Argument.IsNotNull(nameof(suspensionContext), suspensionContext);
-            Argument.IsValid(nameof(suspensionContext.Mode), suspensionContext.Mode, mode => mode == SuspensionMode.MixedBash);
-
-            var i = 0;
-            var changedItems = new List<T>();
-            var changedItemIndices = new List<int>();
-            var previousAction = (NotifyCollectionChangedAction?)null;
-            var eventArgsList = new List<NotifyRangedCollectionChangedEventArgs>();
-            foreach (var action in suspensionContext.MixedActions)
-            {
-                // If action changed, create event args for remembered items
-                if (previousAction.HasValue && action != previousAction.Value)
-                {
-                    // Create and add event args
-                    eventArgsList.Add(new NotifyRangedCollectionChangedEventArgs(changedItems, changedItemIndices, SuspensionMode.MixedBash, previousAction.Value));
-
-                    // Reset lists
-                    changedItems = new List<T>();
-                    changedItemIndices = new List<int>();
-                }
-
-                // Remember item and index
-                changedItems.Add(suspensionContext.ChangedItems[i]);
-                changedItemIndices.Add(suspensionContext.ChangedItemIndices[i]);
-
-                // Update to current action
-                previousAction = action;
-
-                i++;
-            }
-
-            // Create event args for last item(s)
-            if (changedItems.Count != 0)
-            {
-                // ReSharper disable once PossibleInvalidOperationException
-                eventArgsList.Add(new NotifyRangedCollectionChangedEventArgs(changedItems, changedItemIndices, SuspensionMode.MixedBash, previousAction.Value));
-            }
-
-            return eventArgsList;
-        }
-        #endregion Methods
+      return suspensionContext.CreateBashEventArgsList(SuspensionMode.MixedBash);
     }
+
+    /// <summary>
+    /// The create mixed consolidate event args list.
+    /// </summary>
+    /// <param name="suspensionContext">The suspension context.</param>
+    /// <typeparam name="T">The type of collection item.</typeparam>
+    /// <returns>The <see cref="ICollection{NotifyRangedCollectionChangedEventArgs}"/>.</returns>
+    public static ICollection<NotifyRangedCollectionChangedEventArgs> CreateMixedConsolidateEventArgsList<T>(this SuspensionContext<T> suspensionContext)
+    {
+      Argument.IsNotNull(nameof(suspensionContext), suspensionContext);
+      Argument.IsValid(nameof(suspensionContext.Mode), suspensionContext.Mode, mode => mode == SuspensionMode.MixedConsolidate);
+
+      var events = suspensionContext.CreateBashEventArgsList(SuspensionMode.MixedConsolidate);
+
+      bool consolidated;
+      do
+      {
+        consolidated = false;
+        for (int i = events.Count - 1; i >= 1; i--)
+        {
+          var currentEvent = events[i];
+          var previousEvent = events[i - 1];
+          if (currentEvent.Action != previousEvent.Action)
+          {
+            for (int j = currentEvent.Indices.Count - 1; j >= 0; j--)
+            {
+              var index = currentEvent.Indices[j];
+              var item = currentEvent.ChangedItems[j];
+
+              var indexOnPreviousEvent = previousEvent.Indices.IndexOf(index);
+              if (indexOnPreviousEvent != -1 && Equals(previousEvent.ChangedItems[indexOnPreviousEvent], item))
+              {
+                previousEvent.Indices.RemoveAt(indexOnPreviousEvent);
+                previousEvent.ChangedItems.RemoveAt(indexOnPreviousEvent);
+                previousEvent = events[i - 1] = new NotifyRangedCollectionChangedEventArgs(previousEvent.ChangedItems, previousEvent.Indices, SuspensionMode.MixedConsolidate, previousEvent.Action);
+
+                currentEvent.Indices.RemoveAt(j);
+                currentEvent.ChangedItems.RemoveAt(j);
+
+                consolidated = true;
+              }
+            }
+
+            if (consolidated)
+            {
+              if (currentEvent.Indices.Count == 0)
+              {
+                events.RemoveAt(i);
+              }
+              else
+              {
+                events[i] = new NotifyRangedCollectionChangedEventArgs(currentEvent.ChangedItems, currentEvent.Indices, SuspensionMode.MixedConsolidate, currentEvent.Action);
+              }
+            }
+          }
+          else
+          {
+            var changedIndexes = previousEvent.Indices;
+            changedIndexes.AddRange(currentEvent.Indices);
+
+            var changedItems = previousEvent.ChangedItems.Cast<T>().ToList();
+            changedItems.AddRange(currentEvent.ChangedItems.Cast<T>());
+
+            events[i - 1] = new NotifyRangedCollectionChangedEventArgs(changedItems, changedIndexes, SuspensionMode.MixedConsolidate, previousEvent.Action);
+            events.RemoveAt(i);
+
+            consolidated = true;
+          }
+        }
+      }
+      while (consolidated);
+
+      return events;
+    }
+
+    /// <summary>
+    /// The is mixed mode.
+    /// </summary>
+    /// <param name="suspensionContext">The suspension context.</param>
+    /// <typeparam name="T">The type of collection item.</typeparam>
+    /// <returns><c>True</c> if <see cref="SuspensionMode"/> is one of the mixed modes; otherwise, <c>false</c>.</returns>
+    public static bool IsMixedMode<T>(this SuspensionContext<T> suspensionContext)
+    {
+      Argument.IsNotNull(nameof(suspensionContext), suspensionContext);
+
+      return suspensionContext.Mode.IsMixedMode();
+    }
+
+    /// <summary>
+    /// The create bash event args list.
+    /// </summary>
+    /// <param name="suspensionContext">The suspension context.</param>
+    /// <param name="suspensionMode">The suspension mode.</param>
+    /// <typeparam name="T">The type of collection item.</typeparam>
+    /// <returns>The <see cref="IList{NotifyRangedCollectionChangedEventArgs}"/>.</returns>
+    private static IList<NotifyRangedCollectionChangedEventArgs> CreateBashEventArgsList<T>(this SuspensionContext<T> suspensionContext, SuspensionMode suspensionMode)
+    {
+      var i = 0;
+      var changedItems = new List<T>();
+      var changedItemIndices = new List<int>();
+      var previousAction = (NotifyCollectionChangedAction?)null;
+      var eventArgsList = new List<NotifyRangedCollectionChangedEventArgs>();
+      foreach (var action in suspensionContext.MixedActions)
+      {
+        // If action changed, create event args for remembered items
+        if (previousAction.HasValue && action != previousAction.Value)
+        {
+          // Create and add event args
+          eventArgsList.Add(new NotifyRangedCollectionChangedEventArgs(changedItems, changedItemIndices, suspensionMode, previousAction.Value));
+
+          // Reset lists
+          changedItems = new List<T>();
+          changedItemIndices = new List<int>();
+        }
+
+        // Remember item and index
+        changedItems.Add(suspensionContext.ChangedItems[i]);
+        changedItemIndices.Add(suspensionContext.ChangedItemIndices[i]);
+
+        // Update to current action
+        previousAction = action;
+
+        i++;
+      }
+
+      // Create event args for last item(s)
+      if (changedItems.Count != 0)
+      {
+        // ReSharper disable once PossibleInvalidOperationException
+        eventArgsList.Add(new NotifyRangedCollectionChangedEventArgs(changedItems, changedItemIndices, suspensionMode, previousAction.Value));
+      }
+
+      return eventArgsList;
+    }
+    #endregion Methods
+  }
 }

--- a/src/Catel.MVVM/Catel.MVVM.Shared/Collections/Extensions/SuspensionContextExtensions.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/Collections/Extensions/SuspensionContextExtensions.cs
@@ -5,231 +5,231 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 
-namespace Catel.Collections.Extensions
+namespace Catel.Collections
 {
-  using System;
-  using System.Collections.Generic;
-  using System.Collections.Specialized;
-  using System.Linq;
-
-  /// <summary>
-  /// The suspension context extensions.
-  /// </summary>
-  internal static class SuspensionContextExtensions
-  {
-    #region Methods
-    /// <summary>
-    /// The create event args list.
-    /// </summary>
-    /// <param name="suspensionContext">The suspension context.</param>
-    /// <typeparam name="T">The type of collection item.</typeparam>
-    /// <returns>The <see cref="ICollection{NotifyRangedCollectionChangedEventArgs}"/>.</returns>
-    public static ICollection<NotifyRangedCollectionChangedEventArgs> CreateEventArgsList<T>(this SuspensionContext<T> suspensionContext)
-    {
-      // No suspension context is the same as None mode
-      var mode = suspensionContext?.Mode ?? SuspensionMode.None;
-
-      // Fast return for no items in not None modes
-      // ReSharper disable once PossibleNullReferenceException
-      if (mode != SuspensionMode.None && suspensionContext.ChangedItems.Count == 0)
-      {
-        return new NotifyRangedCollectionChangedEventArgs[] { };
-      }
-
-      // Determine creation depending on mode
-      ICollection<NotifyRangedCollectionChangedEventArgs> eventArgsList = new List<NotifyRangedCollectionChangedEventArgs>();
-      switch (mode)
-      {
-        case SuspensionMode.None:
-          {
-            eventArgsList.Add(new NotifyRangedCollectionChangedEventArgs());
-            break;
-          }
-
-        case SuspensionMode.Adding:
-        case SuspensionMode.Removing:
-          {
-            // ReSharper disable once PossibleNullReferenceException
-            eventArgsList.Add(new NotifyRangedCollectionChangedEventArgs(suspensionContext.ChangedItems, suspensionContext.ChangedItemIndices, mode));
-            break;
-          }
-
-        case SuspensionMode.Mixed:
-          {
-            // ReSharper disable once PossibleNullReferenceException
-            eventArgsList.Add(new NotifyRangedCollectionChangedEventArgs(suspensionContext.ChangedItems, suspensionContext.ChangedItemIndices, suspensionContext.MixedActions));
-            break;
-          }
-
-        case SuspensionMode.MixedBash:
-          {
-            eventArgsList = suspensionContext.CreateMixedBashEventArgsList();
-            break;
-          }
-
-        case SuspensionMode.MixedConsolidate:
-          {
-            eventArgsList = suspensionContext.CreateMixedConsolidateEventArgsList();
-            break;
-          }
-
-        default:
-          {
-            // ReSharper disable once LocalizableElement
-            throw new ArgumentOutOfRangeException(nameof(mode), $"The suspension mode '{mode}' is unhandled.");
-          }
-      }
-
-      return eventArgsList;
-    }
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Specialized;
+    using System.Linq;
 
     /// <summary>
-    /// The create mixed bash event args list.
+    /// The suspension context extensions.
     /// </summary>
-    /// <param name="suspensionContext">The suspension context.</param>
-    /// <typeparam name="T">The type of collection item.</typeparam>
-    /// <returns>The <see cref="ICollection{NotifyRangedCollectionChangedEventArgs}"/>.</returns>
-    public static ICollection<NotifyRangedCollectionChangedEventArgs> CreateMixedBashEventArgsList<T>(this SuspensionContext<T> suspensionContext)
+    internal static class SuspensionContextExtensions
     {
-      Argument.IsNotNull(nameof(suspensionContext), suspensionContext);
-      Argument.IsValid(nameof(suspensionContext.Mode), suspensionContext.Mode, mode => mode == SuspensionMode.MixedBash);
-
-      return suspensionContext.CreateBashEventArgsList(SuspensionMode.MixedBash);
-    }
-
-    /// <summary>
-    /// The create mixed consolidate event args list.
-    /// </summary>
-    /// <param name="suspensionContext">The suspension context.</param>
-    /// <typeparam name="T">The type of collection item.</typeparam>
-    /// <returns>The <see cref="ICollection{NotifyRangedCollectionChangedEventArgs}"/>.</returns>
-    public static ICollection<NotifyRangedCollectionChangedEventArgs> CreateMixedConsolidateEventArgsList<T>(this SuspensionContext<T> suspensionContext)
-    {
-      Argument.IsNotNull(nameof(suspensionContext), suspensionContext);
-      Argument.IsValid(nameof(suspensionContext.Mode), suspensionContext.Mode, mode => mode == SuspensionMode.MixedConsolidate);
-
-      var events = suspensionContext.CreateBashEventArgsList(SuspensionMode.MixedConsolidate);
-
-      bool consolidated;
-      do
-      {
-        consolidated = false;
-        for (int i = events.Count - 1; i >= 1; i--)
+        #region Methods
+        /// <summary>
+        /// The create event args list.
+        /// </summary>
+        /// <param name="suspensionContext">The suspension context.</param>
+        /// <typeparam name="T">The type of collection item.</typeparam>
+        /// <returns>The <see cref="ICollection{NotifyRangedCollectionChangedEventArgs}"/>.</returns>
+        public static ICollection<NotifyRangedCollectionChangedEventArgs> CreateEventArgsList<T>(this SuspensionContext<T> suspensionContext)
         {
-          var currentEvent = events[i];
-          var previousEvent = events[i - 1];
-          if (currentEvent.Action != previousEvent.Action)
-          {
-            for (int j = currentEvent.Indices.Count - 1; j >= 0; j--)
+            // No suspension context is the same as None mode
+            var mode = suspensionContext?.Mode ?? SuspensionMode.None;
+
+            // Fast return for no items in not None modes
+            // ReSharper disable once PossibleNullReferenceException
+            if (mode != SuspensionMode.None && suspensionContext.ChangedItems.Count == 0)
             {
-              var index = currentEvent.Indices[j];
-              var item = currentEvent.ChangedItems[j];
-
-              var indexOnPreviousEvent = previousEvent.Indices.IndexOf(index);
-              if (indexOnPreviousEvent != -1 && Equals(previousEvent.ChangedItems[indexOnPreviousEvent], item))
-              {
-                previousEvent.Indices.RemoveAt(indexOnPreviousEvent);
-                previousEvent.ChangedItems.RemoveAt(indexOnPreviousEvent);
-                previousEvent = events[i - 1] = new NotifyRangedCollectionChangedEventArgs(previousEvent.ChangedItems, previousEvent.Indices, SuspensionMode.MixedConsolidate, previousEvent.Action);
-
-                currentEvent.Indices.RemoveAt(j);
-                currentEvent.ChangedItems.RemoveAt(j);
-
-                consolidated = true;
-              }
+                return ArrayShim.Empty<NotifyRangedCollectionChangedEventArgs>();
             }
 
-            if (consolidated)
+            // Determine creation depending on mode
+            ICollection<NotifyRangedCollectionChangedEventArgs> eventArgsList = new List<NotifyRangedCollectionChangedEventArgs>();
+            switch (mode)
             {
-              if (currentEvent.Indices.Count == 0)
-              {
-                events.RemoveAt(i);
-              }
-              else
-              {
-                events[i] = new NotifyRangedCollectionChangedEventArgs(currentEvent.ChangedItems, currentEvent.Indices, SuspensionMode.MixedConsolidate, currentEvent.Action);
-              }
+                case SuspensionMode.None:
+                    {
+                        eventArgsList.Add(new NotifyRangedCollectionChangedEventArgs());
+                        break;
+                    }
+
+                case SuspensionMode.Adding:
+                case SuspensionMode.Removing:
+                    {
+                        // ReSharper disable once PossibleNullReferenceException
+                        eventArgsList.Add(new NotifyRangedCollectionChangedEventArgs(suspensionContext.ChangedItems, suspensionContext.ChangedItemIndices, mode));
+                        break;
+                    }
+
+                case SuspensionMode.Mixed:
+                    {
+                        // ReSharper disable once PossibleNullReferenceException
+                        eventArgsList.Add(new NotifyRangedCollectionChangedEventArgs(suspensionContext.ChangedItems, suspensionContext.ChangedItemIndices, suspensionContext.MixedActions));
+                        break;
+                    }
+
+                case SuspensionMode.MixedBash:
+                    {
+                        eventArgsList = suspensionContext.CreateMixedBashEventArgsList();
+                        break;
+                    }
+
+                case SuspensionMode.MixedConsolidate:
+                    {
+                        eventArgsList = suspensionContext.CreateMixedConsolidateEventArgsList();
+                        break;
+                    }
+
+                default:
+                    {
+                        // ReSharper disable once LocalizableElement
+                        throw new ArgumentOutOfRangeException(nameof(mode), $"The suspension mode '{mode}' is unhandled.");
+                    }
             }
-          }
-          else
-          {
-            var changedIndexes = previousEvent.Indices;
-            changedIndexes.AddRange(currentEvent.Indices);
 
-            var changedItems = previousEvent.ChangedItems.Cast<T>().ToList();
-            changedItems.AddRange(currentEvent.ChangedItems.Cast<T>());
-
-            events[i - 1] = new NotifyRangedCollectionChangedEventArgs(changedItems, changedIndexes, SuspensionMode.MixedConsolidate, previousEvent.Action);
-            events.RemoveAt(i);
-
-            consolidated = true;
-          }
+            return eventArgsList;
         }
-      }
-      while (consolidated);
 
-      return events;
-    }
-
-    /// <summary>
-    /// The is mixed mode.
-    /// </summary>
-    /// <param name="suspensionContext">The suspension context.</param>
-    /// <typeparam name="T">The type of collection item.</typeparam>
-    /// <returns><c>True</c> if <see cref="SuspensionMode"/> is one of the mixed modes; otherwise, <c>false</c>.</returns>
-    public static bool IsMixedMode<T>(this SuspensionContext<T> suspensionContext)
-    {
-      Argument.IsNotNull(nameof(suspensionContext), suspensionContext);
-
-      return suspensionContext.Mode.IsMixedMode();
-    }
-
-    /// <summary>
-    /// The create bash event args list.
-    /// </summary>
-    /// <param name="suspensionContext">The suspension context.</param>
-    /// <param name="suspensionMode">The suspension mode.</param>
-    /// <typeparam name="T">The type of collection item.</typeparam>
-    /// <returns>The <see cref="IList{NotifyRangedCollectionChangedEventArgs}"/>.</returns>
-    private static IList<NotifyRangedCollectionChangedEventArgs> CreateBashEventArgsList<T>(this SuspensionContext<T> suspensionContext, SuspensionMode suspensionMode)
-    {
-      var i = 0;
-      var changedItems = new List<T>();
-      var changedItemIndices = new List<int>();
-      var previousAction = (NotifyCollectionChangedAction?)null;
-      var eventArgsList = new List<NotifyRangedCollectionChangedEventArgs>();
-      foreach (var action in suspensionContext.MixedActions)
-      {
-        // If action changed, create event args for remembered items
-        if (previousAction.HasValue && action != previousAction.Value)
+        /// <summary>
+        /// The create mixed bash event args list.
+        /// </summary>
+        /// <param name="suspensionContext">The suspension context.</param>
+        /// <typeparam name="T">The type of collection item.</typeparam>
+        /// <returns>The <see cref="ICollection{NotifyRangedCollectionChangedEventArgs}"/>.</returns>
+        public static ICollection<NotifyRangedCollectionChangedEventArgs> CreateMixedBashEventArgsList<T>(this SuspensionContext<T> suspensionContext)
         {
-          // Create and add event args
-          eventArgsList.Add(new NotifyRangedCollectionChangedEventArgs(changedItems, changedItemIndices, suspensionMode, previousAction.Value));
+            Argument.IsNotNull(nameof(suspensionContext), suspensionContext);
+            Argument.IsValid(nameof(suspensionContext.Mode), suspensionContext.Mode, mode => mode == SuspensionMode.MixedBash);
 
-          // Reset lists
-          changedItems = new List<T>();
-          changedItemIndices = new List<int>();
+            return suspensionContext.CreateBashEventArgsList(SuspensionMode.MixedBash);
         }
 
-        // Remember item and index
-        changedItems.Add(suspensionContext.ChangedItems[i]);
-        changedItemIndices.Add(suspensionContext.ChangedItemIndices[i]);
+        /// <summary>
+        /// The create mixed consolidate event args list.
+        /// </summary>
+        /// <param name="suspensionContext">The suspension context.</param>
+        /// <typeparam name="T">The type of collection item.</typeparam>
+        /// <returns>The <see cref="ICollection{NotifyRangedCollectionChangedEventArgs}"/>.</returns>
+        public static ICollection<NotifyRangedCollectionChangedEventArgs> CreateMixedConsolidateEventArgsList<T>(this SuspensionContext<T> suspensionContext)
+        {
+            Argument.IsNotNull(nameof(suspensionContext), suspensionContext);
+            Argument.IsValid(nameof(suspensionContext.Mode), suspensionContext.Mode, mode => mode == SuspensionMode.MixedConsolidate);
 
-        // Update to current action
-        previousAction = action;
+            var events = suspensionContext.CreateBashEventArgsList(SuspensionMode.MixedConsolidate);
 
-        i++;
-      }
+            bool consolidated;
+            do
+            {
+                consolidated = false;
+                for (int i = events.Count - 1; i >= 1; i--)
+                {
+                    var currentEvent = events[i];
+                    var previousEvent = events[i - 1];
+                    if (currentEvent.Action != previousEvent.Action)
+                    {
+                        for (int j = currentEvent.Indices.Count - 1; j >= 0; j--)
+                        {
+                            var index = currentEvent.Indices[j];
+                            var item = currentEvent.ChangedItems[j];
 
-      // Create event args for last item(s)
-      if (changedItems.Count != 0)
-      {
-        // ReSharper disable once PossibleInvalidOperationException
-        eventArgsList.Add(new NotifyRangedCollectionChangedEventArgs(changedItems, changedItemIndices, suspensionMode, previousAction.Value));
-      }
+                            var indexOnPreviousEvent = previousEvent.Indices.IndexOf(index);
+                            if (indexOnPreviousEvent != -1 && Equals(previousEvent.ChangedItems[indexOnPreviousEvent], item))
+                            {
+                                previousEvent.Indices.RemoveAt(indexOnPreviousEvent);
+                                previousEvent.ChangedItems.RemoveAt(indexOnPreviousEvent);
+                                previousEvent = events[i - 1] = new NotifyRangedCollectionChangedEventArgs(previousEvent.ChangedItems, previousEvent.Indices, SuspensionMode.MixedConsolidate, previousEvent.Action);
 
-      return eventArgsList;
+                                currentEvent.Indices.RemoveAt(j);
+                                currentEvent.ChangedItems.RemoveAt(j);
+
+                                consolidated = true;
+                            }
+                        }
+
+                        if (consolidated)
+                        {
+                            if (currentEvent.Indices.Count == 0)
+                            {
+                                events.RemoveAt(i);
+                            }
+                            else
+                            {
+                                events[i] = new NotifyRangedCollectionChangedEventArgs(currentEvent.ChangedItems, currentEvent.Indices, SuspensionMode.MixedConsolidate, currentEvent.Action);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        var changedIndexes = previousEvent.Indices;
+                        changedIndexes.AddRange(currentEvent.Indices);
+
+                        var changedItems = previousEvent.ChangedItems.Cast<T>().ToList();
+                        changedItems.AddRange(currentEvent.ChangedItems.Cast<T>());
+
+                        events[i - 1] = new NotifyRangedCollectionChangedEventArgs(changedItems, changedIndexes, SuspensionMode.MixedConsolidate, previousEvent.Action);
+                        events.RemoveAt(i);
+
+                        consolidated = true;
+                    }
+                }
+            }
+            while (consolidated);
+
+            return events;
+        }
+
+        /// <summary>
+        /// The is mixed mode.
+        /// </summary>
+        /// <param name="suspensionContext">The suspension context.</param>
+        /// <typeparam name="T">The type of collection item.</typeparam>
+        /// <returns><c>True</c> if <see cref="SuspensionMode"/> is one of the mixed modes; otherwise, <c>false</c>.</returns>
+        public static bool IsMixedMode<T>(this SuspensionContext<T> suspensionContext)
+        {
+            Argument.IsNotNull(nameof(suspensionContext), suspensionContext);
+
+            return suspensionContext.Mode.IsMixedMode();
+        }
+
+        /// <summary>
+        /// The create bash event args list.
+        /// </summary>
+        /// <param name="suspensionContext">The suspension context.</param>
+        /// <param name="suspensionMode">The suspension mode.</param>
+        /// <typeparam name="T">The type of collection item.</typeparam>
+        /// <returns>The <see cref="IList{NotifyRangedCollectionChangedEventArgs}"/>.</returns>
+        private static IList<NotifyRangedCollectionChangedEventArgs> CreateBashEventArgsList<T>(this SuspensionContext<T> suspensionContext, SuspensionMode suspensionMode)
+        {
+            var i = 0;
+            var changedItems = new List<T>();
+            var changedItemIndices = new List<int>();
+            var previousAction = (NotifyCollectionChangedAction?)null;
+            var eventArgsList = new List<NotifyRangedCollectionChangedEventArgs>();
+            foreach (var action in suspensionContext.MixedActions)
+            {
+                // If action changed, create event args for remembered items
+                if (previousAction.HasValue && action != previousAction.Value)
+                {
+                    // Create and add event args
+                    eventArgsList.Add(new NotifyRangedCollectionChangedEventArgs(changedItems, changedItemIndices, suspensionMode, previousAction.Value));
+
+                    // Reset lists
+                    changedItems = new List<T>();
+                    changedItemIndices = new List<int>();
+                }
+
+                // Remember item and index
+                changedItems.Add(suspensionContext.ChangedItems[i]);
+                changedItemIndices.Add(suspensionContext.ChangedItemIndices[i]);
+
+                // Update to current action
+                previousAction = action;
+
+                i++;
+            }
+
+            // Create event args for last item(s)
+            if (changedItems.Count != 0)
+            {
+                // ReSharper disable once PossibleInvalidOperationException
+                eventArgsList.Add(new NotifyRangedCollectionChangedEventArgs(changedItems, changedItemIndices, suspensionMode, previousAction.Value));
+            }
+
+            return eventArgsList;
+        }
+        #endregion Methods
     }
-    #endregion Methods
-  }
 }

--- a/src/Catel.MVVM/Catel.MVVM.Shared/Collections/Extensions/SuspensionModeExtensions.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/Collections/Extensions/SuspensionModeExtensions.cs
@@ -6,7 +6,6 @@
 
 namespace Catel.Collections
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
 

--- a/src/Catel.MVVM/Catel.MVVM.Shared/Collections/FastObservableCollection.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/Collections/FastObservableCollection.cs
@@ -13,6 +13,7 @@ namespace Catel.Collections
     using System.Collections.Specialized;
     using System.ComponentModel;
 
+    using Catel.Collections.Extensions;
     using Catel.IoC;
     using Catel.Logging;
     using Catel.Services;

--- a/src/Catel.MVVM/Catel.MVVM.Shared/Collections/FastObservableCollection.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/Collections/FastObservableCollection.cs
@@ -13,7 +13,6 @@ namespace Catel.Collections
     using System.Collections.Specialized;
     using System.ComponentModel;
 
-    using Catel.Collections.Extensions;
     using Catel.IoC;
     using Catel.Logging;
     using Catel.Services;

--- a/src/Catel.Test/Catel.Test.Shared/Collections/FastObservableCollectionFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Collections/FastObservableCollectionFacts.cs
@@ -1472,7 +1472,7 @@ namespace Catel.Test.Collections
             }
 
             [Test]
-            public void RaisesTwoEventsForAddingAndMovingItems()
+            public void RaisesSingleEventsForAddingAndMovingItems()
             {
                 var eventArgsList = new List<NotifyRangedCollectionChangedEventArgs>();
                 var sourceCollection = new FastObservableCollection<int>();

--- a/src/Catel.Test/Catel.Test.Shared/Collections/FastObservableCollectionFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Collections/FastObservableCollectionFacts.cs
@@ -1308,5 +1308,241 @@ namespace Catel.Test.Collections
                 CollectionAssert.AreEqual(sourceCollection, targetCollection);
             }
         }
+        
+        [TestFixture]
+        public class TheMixedConsolidateMode
+        {
+            [Test]
+            public void EventArgsContainMixedItemsAfterClearing()
+            {
+                var eventArgsList = new List<NotifyRangedCollectionChangedEventArgs>();
+                var fastCollection = new FastObservableCollection<int> { 1, 2, 3 };
+                fastCollection.AutomaticallyDispatchChangeNotifications = false;
+                fastCollection.CollectionChanged += (sender, args) => { eventArgsList.Add((NotifyRangedCollectionChangedEventArgs)args); };
+
+                using (fastCollection.SuspendChangeNotifications(SuspensionMode.MixedConsolidate))
+                {
+                    fastCollection.Clear(); // { }
+                }
+
+                Assert.AreEqual(1, eventArgsList.Count);
+                Assert.AreEqual(NotifyCollectionChangedAction.Remove, eventArgsList[0].Action);
+                Assert.AreEqual(3, eventArgsList.First(args => args.SuspensionMode == SuspensionMode.MixedConsolidate).ChangedItems.Count);
+            }
+
+            [Test]
+            public void TargetCollectionAimsSourceCollectionChanges()
+            {
+                var eventArgsList = new List<NotifyRangedCollectionChangedEventArgs>();
+                var sourceCollection = new FastObservableCollection<int> { 1, 2, 3, 4, 5 };
+                sourceCollection.AutomaticallyDispatchChangeNotifications = false;
+                sourceCollection.CollectionChanged += (sender, args) => { eventArgsList.Add((NotifyRangedCollectionChangedEventArgs)args); };
+
+                using (sourceCollection.SuspendChangeNotifications(SuspensionMode.MixedConsolidate))
+                {
+                    sourceCollection.Add(6); // { 1, 2, 3, 4, 5, 6 };
+                    sourceCollection.Remove(3); // { 1, 2, 4, 5, 6 };
+                    sourceCollection.Add(7); // { 1, 2, 4, 5, 6, 7 };
+                    sourceCollection.Remove(4); // { 1, 2, 5, 6, 7 };
+                    sourceCollection.Remove(5); // { 1, 2, 6, 7 };
+                    sourceCollection.Add(3); // { 1, 2, 6, 7, 3 };
+                }
+
+                Assert.AreEqual(5, eventArgsList.Count);
+                Assert.AreEqual(NotifyCollectionChangedAction.Add, eventArgsList[0].Action);
+                Assert.AreEqual(NotifyCollectionChangedAction.Remove, eventArgsList[1].Action);
+                Assert.AreEqual(NotifyCollectionChangedAction.Add, eventArgsList[2].Action);
+                Assert.AreEqual(NotifyCollectionChangedAction.Remove, eventArgsList[3].Action);
+                Assert.AreEqual(NotifyCollectionChangedAction.Add, eventArgsList[4].Action);
+
+                var targetCollection = new List<int> { 1, 2, 3, 4, 5 };
+                FastObservableCollectionFactsHelper.Synchronize(targetCollection, sourceCollection, eventArgsList);
+                CollectionAssert.AreEqual(sourceCollection, targetCollection);
+            }
+
+            [Test]
+            public void TargetCollectionAimsSourceCollectionChangesWithReplacingItem()
+            {
+                var eventArgsList = new List<NotifyRangedCollectionChangedEventArgs>();
+                var sourceCollection = new FastObservableCollection<int> { 1, 2, 3, 4, 5 };
+                sourceCollection.AutomaticallyDispatchChangeNotifications = false;
+                sourceCollection.CollectionChanged += (sender, args) => { eventArgsList.Add((NotifyRangedCollectionChangedEventArgs)args); };
+
+                using (sourceCollection.SuspendChangeNotifications(SuspensionMode.MixedConsolidate))
+                {
+                    sourceCollection[0] = 6; // { 6, 2, 3, 4, 5 };
+                }
+
+                Assert.AreEqual(2, eventArgsList.Count);
+                Assert.AreEqual(NotifyCollectionChangedAction.Remove, eventArgsList[0].Action);
+                Assert.AreEqual(NotifyCollectionChangedAction.Add, eventArgsList[1].Action);
+
+                var targetCollection = new List<int> { 1, 2, 3, 4, 5 };
+                FastObservableCollectionFactsHelper.Synchronize(targetCollection, sourceCollection, eventArgsList);
+                CollectionAssert.AreEqual(sourceCollection, targetCollection);
+            }
+
+            [Test]
+            public void RaisesTwoEventForMovingItems()
+            {
+                var eventArgsList = new List<NotifyRangedCollectionChangedEventArgs>();
+                var sourceCollection = new FastObservableCollection<int> { 1, 2, 3, 4, 5 };
+                sourceCollection.AutomaticallyDispatchChangeNotifications = false;
+                sourceCollection.CollectionChanged += (sender, args) => { eventArgsList.Add((NotifyRangedCollectionChangedEventArgs)args); };
+
+                using (sourceCollection.SuspendChangeNotifications(SuspensionMode.MixedConsolidate))
+                {
+                    sourceCollection.Move(0, 3); // { 2, 3, 4, 1, 5 }
+                }
+
+                Assert.AreEqual(2, eventArgsList.Count);
+                Assert.AreEqual(NotifyCollectionChangedAction.Remove, eventArgsList[0].Action);
+                Assert.AreEqual(NotifyCollectionChangedAction.Add, eventArgsList[1].Action);
+
+                var targetCollection = new List<int> { 1, 2, 3, 4, 5 };
+                FastObservableCollectionFactsHelper.Synchronize(targetCollection, sourceCollection, eventArgsList);
+                CollectionAssert.AreEqual(sourceCollection, targetCollection);
+            }
+
+            [Test]
+            public void RaisesTwoEventForSimulatedMovingItems()
+            {
+                var eventArgsList = new List<NotifyRangedCollectionChangedEventArgs>();
+                var sourceCollection = new FastObservableCollection<int> { 1, 2, 3, 4, 5 };
+                sourceCollection.AutomaticallyDispatchChangeNotifications = false;
+                sourceCollection.CollectionChanged += (sender, args) => { eventArgsList.Add((NotifyRangedCollectionChangedEventArgs)args); };
+
+                using (sourceCollection.SuspendChangeNotifications(SuspensionMode.MixedConsolidate))
+                {
+                    sourceCollection.Remove(1); // { 2, 3, 4, 5 }
+                    sourceCollection.Insert(3, 1); // { 2, 3, 4, 1, 5 }
+                }
+
+                Assert.AreEqual(2, eventArgsList.Count);
+                Assert.AreEqual(NotifyCollectionChangedAction.Remove, eventArgsList[0].Action);
+                Assert.AreEqual(NotifyCollectionChangedAction.Add, eventArgsList[1].Action);
+
+                var targetCollection = new List<int> { 1, 2, 3, 4, 5 };
+                FastObservableCollectionFactsHelper.Synchronize(targetCollection, sourceCollection, eventArgsList);
+                CollectionAssert.AreEqual(sourceCollection, targetCollection);
+            }
+
+            [Test]
+            public void RaisesSingleEventForAddingItems()
+            {
+                var eventArgsList = new List<NotifyRangedCollectionChangedEventArgs>();
+                var sourceCollection = new FastObservableCollection<int> { };
+                sourceCollection.AutomaticallyDispatchChangeNotifications = false;
+                sourceCollection.CollectionChanged += (sender, args) => { eventArgsList.Add((NotifyRangedCollectionChangedEventArgs)args); };
+
+                using (sourceCollection.SuspendChangeNotifications(SuspensionMode.MixedConsolidate))
+                {
+                    sourceCollection.Add(1); // { 1 }
+                    sourceCollection.Add(2); // { 1, 2 }
+                }
+
+                Assert.AreEqual(1, eventArgsList.Count);
+                Assert.AreEqual(NotifyCollectionChangedAction.Add, eventArgsList[0].Action);
+
+                var targetCollection = new List<int> { };
+                FastObservableCollectionFactsHelper.Synchronize(targetCollection, sourceCollection, eventArgsList);
+                CollectionAssert.AreEqual(sourceCollection, targetCollection);
+            }
+
+            [Test]
+            public void RaisesSingleEventForInsertingItems()
+            {
+                var eventArgsList = new List<NotifyRangedCollectionChangedEventArgs>();
+                var sourceCollection = new FastObservableCollection<int> { };
+                sourceCollection.AutomaticallyDispatchChangeNotifications = false;
+                sourceCollection.CollectionChanged += (sender, args) => { eventArgsList.Add((NotifyRangedCollectionChangedEventArgs)args); };
+
+                using (sourceCollection.SuspendChangeNotifications(SuspensionMode.MixedConsolidate))
+                {
+                    sourceCollection.Insert(0, 1); // { 1 }
+                    sourceCollection.Insert(1, 2); // { 1, 2 }
+                }
+
+                Assert.AreEqual(1, eventArgsList.Count);
+                Assert.AreEqual(NotifyCollectionChangedAction.Add, eventArgsList[0].Action);
+
+                var targetCollection = new List<int> { };
+                FastObservableCollectionFactsHelper.Synchronize(targetCollection, sourceCollection, eventArgsList);
+                CollectionAssert.AreEqual(sourceCollection, targetCollection);
+            }
+
+            [Test]
+            public void RaisesTwoEventsForAddingAndMovingItems()
+            {
+                var eventArgsList = new List<NotifyRangedCollectionChangedEventArgs>();
+                var sourceCollection = new FastObservableCollection<int>();
+                sourceCollection.AutomaticallyDispatchChangeNotifications = false;
+                sourceCollection.CollectionChanged += (sender, args) => { eventArgsList.Add((NotifyRangedCollectionChangedEventArgs)args); };
+
+                using (sourceCollection.SuspendChangeNotifications(SuspensionMode.MixedConsolidate))
+                {
+                    sourceCollection.Add(2); // { 2 }
+                    sourceCollection.Add(1); // { 2, 1 }
+                    sourceCollection.Move(1, 0); // { 1, 2 }
+                }
+
+                Assert.AreEqual(1, eventArgsList.Count);
+                Assert.AreEqual(NotifyCollectionChangedAction.Add, eventArgsList[0].Action);
+
+                var targetCollection = new List<int>();
+                FastObservableCollectionFactsHelper.Synchronize(targetCollection, sourceCollection, eventArgsList);
+                CollectionAssert.AreEqual(sourceCollection, targetCollection);
+            }
+
+            [Test]
+            public void RaisesSingleEventForAddAndRemoveActions()
+            {
+                var eventArgsList = new List<NotifyRangedCollectionChangedEventArgs>();
+                var fastCollection = new FastObservableCollection<int> { };
+                fastCollection.AutomaticallyDispatchChangeNotifications = false;
+                fastCollection.CollectionChanged += (sender, args) => { eventArgsList.Add((NotifyRangedCollectionChangedEventArgs)args); };
+
+                using (fastCollection.SuspendChangeNotifications(SuspensionMode.MixedConsolidate))
+                {
+                    fastCollection.Add(1);
+                    fastCollection.Add(2);
+                    fastCollection.Add(3);
+                    fastCollection.Remove(3);
+                    fastCollection.Remove(2);
+                    fastCollection.Add(2);
+                }
+
+                Assert.AreEqual(1, eventArgsList.Count);
+                Assert.AreEqual(2, eventArgsList[0].ChangedItems.Count);
+                Assert.AreEqual(2, eventArgsList[0].NewItems.Count);
+                Assert.AreEqual(SuspensionMode.MixedConsolidate, eventArgsList[0].SuspensionMode);
+                Assert.AreEqual(NotifyCollectionChangedAction.Add, eventArgsList[0].Action);
+            }
+
+            [Test]
+            public void TargetCollectionAimsSourceCollectionChangesWithAddingAndRemovingItems()
+            {
+                var eventArgsList = new List<NotifyRangedCollectionChangedEventArgs>();
+                var sourceCollection = new FastObservableCollection<int> { };
+                sourceCollection.AutomaticallyDispatchChangeNotifications = false;
+                sourceCollection.CollectionChanged += (sender, args) => { eventArgsList.Add((NotifyRangedCollectionChangedEventArgs)args); };
+
+                using (sourceCollection.SuspendChangeNotifications(SuspensionMode.MixedConsolidate))
+                {
+                    sourceCollection.Add(1);
+                    sourceCollection.Add(2);
+                    sourceCollection.Add(3);
+                    sourceCollection.Remove(3);
+                    sourceCollection.Remove(2);
+                    sourceCollection.Add(2);
+                }
+
+                Assert.AreEqual(1, eventArgsList.Count);
+
+                var targetCollection = new List<int> { };
+                FastObservableCollectionFactsHelper.Synchronize(targetCollection, sourceCollection, eventArgsList);
+                CollectionAssert.AreEqual(sourceCollection, targetCollection);
+            }
+        }        
     }
 }


### PR DESCRIPTION
Fixes #1096.

### Checklist

- [X] I have included examples or tests
- [X] I have updated the change log
- [X] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Add mode MixedConsolidate to FastObservableCollection