### PR TITLE
(x) Change unit test that fails for SuspensionMode.Mixed in favor to use SuspensionMode.MixedConsolidate

### DIFF
--- a/doc/history.txt
+++ b/doc/history.txt
@@ -36,7 +36,6 @@ Added/fixed:
 (*) #1085 Changed ValidatableModelBase.IsValidationSuspended to be virtual
 (x) #1088 Fix issues with FastObservableCollection especially with SuspensionMode.Mixed
 (x) #1093 Fix Command.Execute bad async implementation (resulting in exceptions not being thrown)
-(x) #1105 Change unit test that fails for SuspensionMode.Mixed in favor to use SuspensionMode.MixedConsolidate
 
 Roadmap:
 ========

--- a/doc/history.txt
+++ b/doc/history.txt
@@ -36,6 +36,7 @@ Added/fixed:
 (*) #1085 Changed ValidatableModelBase.IsValidationSuspended to be virtual
 (x) #1088 Fix issues with FastObservableCollection especially with SuspensionMode.Mixed
 (x) #1093 Fix Command.Execute bad async implementation (resulting in exceptions not being thrown)
+(x) #1105 Change unit test that fails for SuspensionMode.Mixed in favor to use SuspensionMode.MixedConsolidate
 
 Roadmap:
 ========

--- a/src/Catel.Test/Catel.Test.Shared/Data/ChangeNotificationWrapperFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Data/ChangeNotificationWrapperFacts.cs
@@ -218,7 +218,7 @@ namespace Catel.Test.Data
             }
 
             [TestCase]
-            public void HandlesCollectionChangesCorrectlyInSuspensionModeMixed()
+            public void HandlesCollectionChangesCorrectlyInSuspensionModeMixedConsolidate()
             {
                 var collection = new FastObservableCollection<TestModel>();
                 var wrapper = new ChangeNotificationWrapper(collection);
@@ -248,7 +248,7 @@ namespace Catel.Test.Data
                     }
                 };
 
-                using (collection.SuspendChangeNotifications(SuspensionMode.Mixed))
+                using (collection.SuspendChangeNotifications(SuspensionMode.MixedConsolidate))
                 {
                     ((ICollection<TestModel>)collection).ReplaceRange(new [] { new TestModel() });
                 }


### PR DESCRIPTION
Fixes #1105.

### Changes proposed in this pull request:

- Change unit test that fails for SuspensionMode.Mixed in favor to use SuspensionMode.MixedConsolidate