### PR TITLE
(*) 940 Type arrays used to find method by signature are allocated once via TypeArray static class

### DIFF
--- a/src/Catel.Core/Catel.Core.Shared/Catel.Core.Shared.projitems
+++ b/src/Catel.Core/Catel.Core.Shared/Catel.Core.Shared.projitems
@@ -320,6 +320,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Reflection\Helpers\StaticHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Reflection\Helpers\TypeHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Reflection\Interfaces\IEntryAssemblyResolver.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Reflection\TypeArray.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Reflection\TypeCache.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Reflection\TypeInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Runtime\ReferenceEqualityComparer.cs" />

--- a/src/Catel.Core/Catel.Core.Shared/Helpers/ObjectToStringHelper.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Helpers/ObjectToStringHelper.cs
@@ -81,7 +81,9 @@ namespace Catel
 			// for a specific string, use a cast like the DateTime about
 
             // Check if there is a culture specific version
-            var toStringMethod = instanceType.GetMethodEx("ToString", new[] {typeof (IFormatProvider)});
+
+            
+            var toStringMethod = instanceType.GetMethodEx("ToString", TypeArray.From<IFormatProvider>());
             if (toStringMethod != null)
             {
                 return (string)toStringMethod.Invoke(instance, new object[] { cultureInfo });

--- a/src/Catel.Core/Catel.Core.Shared/Logging/Extensions/LogExtensions.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Logging/Extensions/LogExtensions.cs
@@ -192,7 +192,7 @@ namespace Catel.Logging
 
             if (others != null && others.Length > 0)
             {
-                object[] args = {s1, s2, s3, s4, s5};
+                object[] args = { s1, s2, s3, s4, s5 };
                 Array.Resize(ref args, 5 + others.Length);
                 Array.Copy(others, 0, args, 5, others.Length);
 

--- a/src/Catel.Core/Catel.Core.Shared/Reflection/TypeArray.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Reflection/TypeArray.cs
@@ -19,6 +19,45 @@ namespace Catel.Reflection
         /// </summary>
         /// <typeparam name="T1">The type 1</typeparam>
         /// <typeparam name="T2">The type 2</typeparam>
+		/// <typeparam name="T3">The type 3</typeparam>
+		/// <typeparam name="T4">The type 4</typeparam>
+		/// <typeparam name="T5">The type 5</typeparam>		
+        /// <returns>Array of types</returns>
+        public static Type[] From<T1, T2, T3, T4, T5>()
+        {
+            return ArrayCache<T1, T2, T3, T4, T5>.Value;
+        }
+
+        /// <summary>
+        /// Gets an array of type from two type parameters.
+        /// </summary>
+        /// <typeparam name="T1">The type 1</typeparam>
+        /// <typeparam name="T2">The type 2</typeparam>
+		/// <typeparam name="T3">The type 3</typeparam>
+		/// <typeparam name="T4">The type 4</typeparam>	
+        /// <returns>Array of types</returns>
+        public static Type[] From<T1, T2, T3, T4>()
+        {
+            return ArrayCache<T1, T2, T3, T4>.Value;
+        }
+
+        /// <summary>
+        /// Gets an array of type from two type parameters.
+        /// </summary>
+        /// <typeparam name="T1">The type 1</typeparam>
+        /// <typeparam name="T2">The type 2</typeparam>
+		/// <typeparam name="T3">The type 3</typeparam>
+        /// <returns>Array of types</returns>
+        public static Type[] From<T1, T2, T3>()
+        {
+            return ArrayCache<T1, T2, T3>.Value;
+        }
+
+        /// <summary>
+        /// Gets an array of type from two type parameters.
+        /// </summary>
+        /// <typeparam name="T1">The type 1</typeparam>
+        /// <typeparam name="T2">The type 2</typeparam>
         /// <returns>Array of types</returns>
         public static Type[] From<T1, T2>()
         {
@@ -33,6 +72,21 @@ namespace Catel.Reflection
         public static Type[] From<T>()
         {
             return ArrayCache<T>.Value;
+        }
+
+        private static class ArrayCache<T1, T2, T3, T4, T5>
+        {
+            public static readonly Type[] Value = { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5) };
+        }
+
+        private static class ArrayCache<T1, T2, T3, T4>
+        {
+            public static readonly Type[] Value = { typeof(T1), typeof(T2), typeof(T3), typeof(T4) };
+        }
+
+        private static class ArrayCache<T1, T2, T3>
+        {
+            public static readonly Type[] Value = { typeof(T1), typeof(T2), typeof(T3) };
         }
 
         private static class ArrayCache<T1, T2>

--- a/src/Catel.Core/Catel.Core.Shared/Reflection/TypeArray.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Reflection/TypeArray.cs
@@ -1,0 +1,48 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TypeArray.cs" company="Catel development team">
+//   Copyright (c) 2008 - 2015 Catel development team. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+
+namespace Catel.Reflection
+{
+    using System;
+
+    /// <summary>
+    /// The type array class.
+    /// </summary>
+    public static class TypeArray
+    {
+        /// <summary>
+        /// Gets an array of type from two type parameters.
+        /// </summary>
+        /// <typeparam name="T1">The type 1</typeparam>
+        /// <typeparam name="T2">The type 2</typeparam>
+        /// <returns>Array of types</returns>
+        public static Type[] From<T1, T2>()
+        {
+            return ArrayCache<T1, T2>.Value;
+        }
+
+        /// <summary>
+        /// Gets an array of type from two type parameters.
+        /// </summary>
+        /// <typeparam name="T">The type</typeparam>
+        /// <returns>Array of types</returns>
+        public static Type[] From<T>()
+        {
+            return ArrayCache<T>.Value;
+        }
+
+        private static class ArrayCache<T1, T2>
+        {
+            public static readonly Type[] Value = { typeof(T1), typeof(T2) };
+        }
+
+        private static class ArrayCache<T1>
+        {
+            public static readonly Type[] Value = { typeof(T1) };
+        }
+    }
+}

--- a/src/Catel.Core/Catel.Core.Shared/Runtime/Serialization/BinarySerialization/RedirectDeserializationBinder.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Runtime/Serialization/BinarySerialization/RedirectDeserializationBinder.cs
@@ -106,16 +106,12 @@ namespace Catel.Runtime.Serialization.Binary
 
         private bool IsTypeBinarySerializable(Type type)
         {
-            return TypeBinarySerializableCache.GetFromCacheOrFetch(type, () =>
+            if (type == null)
             {
-                if (type == null)
-                {
-                    return false;
-                }
+                return false;
+            }
 
-                var ctor = type.GetConstructor(new[] {typeof (SerializationInfo), typeof (StreamingContext)});
-                return ctor != null;
-            });
+            return TypeBinarySerializableCache.GetFromCacheOrFetch(type, () => type.GetConstructor(TypeArray.From<SerializationInfo, StreamingContext>()) != null);
         }
 
         /// <summary>

--- a/src/Catel.Core/Catel.Core.Shared/Runtime/Serialization/SerializerBase.general.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Runtime/Serialization/SerializerBase.general.cs
@@ -765,9 +765,10 @@ namespace Catel.Runtime.Serialization
         /// <returns></returns>
         protected virtual MethodInfo GetObjectToStringMethod(Type memberType)
         {
+            
             var toStringMethod = _toStringMethodCache.GetFromCacheOrFetch(memberType, () =>
             {
-                var method = memberType.GetMethodEx("ToString", new[] { typeof(IFormatProvider) }, BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
+                var method = memberType.GetMethodEx("ToString", TypeArray.From<IFormatProvider>(), BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
                 return method;
             });
 
@@ -783,7 +784,7 @@ namespace Catel.Runtime.Serialization
         {
             var parseMethod = _parseMethodCache.GetFromCacheOrFetch(memberType, () =>
             {
-                var method = memberType.GetMethodEx("Parse", new[] { typeof(string), typeof(IFormatProvider) }, BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+                var method = memberType.GetMethodEx("Parse", TypeArray.From<string, IFormatProvider>(), BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
                 return method;
             });
 

--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Converters/EnumToVisibilityConverter.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Converters/EnumToVisibilityConverter.cs
@@ -83,7 +83,8 @@ namespace Catel.MVVM.Converters
 
             var genericEnumType = typeof(Enum<>).MakeGenericType(enumType);
             var bindingFlags = BindingFlags.Public | BindingFlags.Static;
-            var parseMethod = genericEnumType.GetMethodEx("Parse", new[] { typeof(string), typeof(bool) }, bindingFlags);
+            
+            var parseMethod = genericEnumType.GetMethodEx("Parse", TypeArray.From<string, bool>(), bindingFlags);
 
             var allowedEnumValues = stringParameter.Split(SplitChars, StringSplitOptions.RemoveEmptyEntries);
             foreach (var allowedEnumValueAsString in allowedEnumValues)

--- a/src/Catel.Test/Catel.Test.Shared/Helpers/ObjectToStringHelperFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Helpers/ObjectToStringHelperFacts.cs
@@ -10,6 +10,7 @@ namespace Catel.Test
 
     using NUnit.Framework;
 
+    [TestFixture]
     public class ObjectToStringHelperFacts
     {
         [TestFixture]


### PR DESCRIPTION
Fixes #940

### Changes proposed in this pull request:

- Type arrays used to find method by signature are allocated once via TypeArray static class