### PR TITLE
(+) Add From method overloads to ArrayType with non-generic parameters and MakeGenericTypeEx as Type extension in order avoid reallocation of the same type arrays

### DIFF
--- a/src/Catel.Core/Catel.Core.Shared/Messaging/Helpers/MessageMediatorHelper.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Messaging/Helpers/MessageMediatorHelper.cs
@@ -63,7 +63,7 @@ namespace Catel.Messaging
                             break;
 
                         case 1:
-                            actionType = typeof(Action<>).MakeGenericType(parameterInfos[0].ParameterType);
+                            actionType = typeof(Action<>).MakeGenericTypeEx(parameterInfos[0].ParameterType);
                             actionParameterType = parameterInfos[0].ParameterType;
                             break;
 

--- a/src/Catel.Core/Catel.Core.Shared/Reflection/Extensions/TypeExtensions.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Reflection/Extensions/TypeExtensions.cs
@@ -189,5 +189,95 @@ namespace Catel.Reflection
             var elementType = genericEnumerableInterface.GetGenericArgumentsEx()[0];
             return elementType;
         }
+
+        /// <summary>
+        /// Substitutes the elements of an array of types for the type parameters of the current generic type definition and returns a <see cref="T:System.Type" /> object representing the resulting constructed type.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <param name="parameterType1">The parameter type 1</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="type"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="parameterType1"/> is <c>null</c>.</exception>
+        public static Type MakeGenericTypeEx(this Type type, Type parameterType1)
+        {
+            Argument.IsNotNull("type", type);
+
+            return type.MakeGenericType(TypeArray.From(parameterType1));
+        }
+
+        /// <summary>
+        /// Substitutes the elements of an array of types for the type parameters of the current generic type definition and returns a <see cref="T:System.Type" /> object representing the resulting constructed type.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <param name="parameterType1">The parameter type 1</param>
+        /// <param name="parameterType2">The parameter type 2</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="type"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="parameterType1"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="parameterType2"/> is <c>null</c>.</exception>
+        public static Type MakeGenericTypeEx(this Type type, Type parameterType1, Type parameterType2)
+        {
+            Argument.IsNotNull("type", type);
+
+            return type.MakeGenericType(TypeArray.From(parameterType1, parameterType2));
+        }
+
+        /// <summary>
+        /// Substitutes the elements of an array of types for the type parameters of the current generic type definition and returns a <see cref="T:System.Type" /> object representing the resulting constructed type.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <param name="parameterType1">The parameter type 1</param>
+        /// <param name="parameterType2">The parameter type 2</param>
+        /// <param name="parameterType3">The parameter type 3</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="type"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="parameterType1"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="parameterType2"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="parameterType3"/> is <c>null</c>.</exception>
+        public static Type MakeGenericTypeEx(this Type type, Type parameterType1, Type parameterType2, Type parameterType3)
+        {
+            Argument.IsNotNull("type", type);
+
+            return type.MakeGenericType(TypeArray.From(parameterType1, parameterType2, parameterType3));
+        }
+
+        /// <summary>
+        /// Substitutes the elements of an array of types for the type parameters of the current generic type definition and returns a <see cref="T:System.Type" /> object representing the resulting constructed type.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <param name="parameterType1">The parameter type 1</param>
+        /// <param name="parameterType2">The parameter type 2</param>
+        /// <param name="parameterType3">The parameter type 3</param>
+        /// <param name="parameterType4">The parameter type 4</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="type"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="parameterType1"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="parameterType2"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="parameterType3"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="parameterType4"/> is <c>null</c>.</exception>
+        public static Type MakeGenericTypeEx(this Type type, Type parameterType1, Type parameterType2, Type parameterType3, Type parameterType4)
+        {
+            Argument.IsNotNull("type", type);
+
+            return type.MakeGenericType(TypeArray.From(parameterType1, parameterType2, parameterType3, parameterType4));
+        }
+
+        /// <summary>
+        /// Substitutes the elements of an array of types for the type parameters of the current generic type definition and returns a <see cref="T:System.Type" /> object representing the resulting constructed type.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <param name="parameterType1">The parameter type 1</param>
+        /// <param name="parameterType2">The parameter type 2</param>
+        /// <param name="parameterType3">The parameter type 3</param>
+        /// <param name="parameterType4">The parameter type 4</param>
+        /// <param name="parameterType5">The parameter type 5</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="type"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="parameterType1"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="parameterType2"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="parameterType3"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="parameterType4"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="parameterType5"/> is <c>null</c>.</exception>
+        public static Type MakeGenericTypeEx(this Type type, Type parameterType1, Type parameterType2, Type parameterType3, Type parameterType4, Type parameterType5)
+        {
+            Argument.IsNotNull("type", type);
+
+            return type.MakeGenericType(TypeArray.From(parameterType1, parameterType2, parameterType3, parameterType4, parameterType5));
+        }
     }
 }

--- a/src/Catel.Core/Catel.Core.Shared/Reflection/Helpers/TypeHelper.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Reflection/Helpers/TypeHelper.cs
@@ -278,7 +278,7 @@ namespace Catel.Reflection
         {
             Argument.IsNotNullOrWhitespace("type", type);
 
-            const string innerTypesEnd = ",";
+            const string InnerTypesEnd = ",";
 
             string newType = type;
             string[] innerTypes = GetInnerTypes(newType);
@@ -315,7 +315,7 @@ namespace Catel.Reflection
 
             if (innerTypes.Length > 0)
             {
-                int innerTypesIndex = stripAssemblies ? newType.Length : newType.IndexOf(innerTypesEnd);
+                int innerTypesIndex = stripAssemblies ? newType.Length : newType.IndexOf(InnerTypesEnd, StringComparison.InvariantCultureIgnoreCase);
                 if (innerTypesIndex >= 0)
                 {
                     newType = newType.Insert(innerTypesIndex, string.Format(CultureInfo.InvariantCulture, "[{0}]", FormatInnerTypes(innerTypes, stripAssemblies)));

--- a/src/Catel.Core/Catel.Core.Shared/Reflection/TypeArray.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Reflection/TypeArray.cs
@@ -8,6 +8,7 @@
 namespace Catel.Reflection
 {
     using System;
+    using System.Reflection;
 
     /// <summary>
     /// The type array class.
@@ -15,13 +16,13 @@ namespace Catel.Reflection
     public static class TypeArray
     {
         /// <summary>
-        /// Gets an array of type from two type parameters.
+        /// Gets an array of type from five type parameters.
         /// </summary>
         /// <typeparam name="T1">The type 1</typeparam>
         /// <typeparam name="T2">The type 2</typeparam>
-		/// <typeparam name="T3">The type 3</typeparam>
-		/// <typeparam name="T4">The type 4</typeparam>
-		/// <typeparam name="T5">The type 5</typeparam>		
+        /// <typeparam name="T3">The type 3</typeparam>
+        /// <typeparam name="T4">The type 4</typeparam>
+        /// <typeparam name="T5">The type 5</typeparam>
         /// <returns>Array of types</returns>
         public static Type[] From<T1, T2, T3, T4, T5>()
         {
@@ -29,12 +30,29 @@ namespace Catel.Reflection
         }
 
         /// <summary>
-        /// Gets an array of type from two type parameters.
+        /// Gets an array of type from five type parameters.
+        /// </summary>
+        /// <param name="type1">The type1</param>
+        /// <param name="type2">The type2</param>
+        /// <param name="type3">The type3</param>
+        /// <param name="type4">The type4</param>
+        /// <param name="type5">The type5</param>
+        /// <returns>Array of types</returns>
+        public static Type[] From(Type type1, Type type2, Type type3, Type type4, Type type5)
+        {
+            var genericType = typeof(ArrayCache<,,,,>).MakeGenericType(type1, type2, type3, type4, type5);
+            var field = genericType.GetFieldEx("Value", BindingFlags.Static | BindingFlags.Public);
+            return (Type[])field.GetValue(genericType);
+        }
+
+
+        /// <summary>
+        /// Gets an array of type from four type parameters.
         /// </summary>
         /// <typeparam name="T1">The type 1</typeparam>
         /// <typeparam name="T2">The type 2</typeparam>
-		/// <typeparam name="T3">The type 3</typeparam>
-		/// <typeparam name="T4">The type 4</typeparam>	
+        /// <typeparam name="T3">The type 3</typeparam>
+        /// <typeparam name="T4">The type 4</typeparam>
         /// <returns>Array of types</returns>
         public static Type[] From<T1, T2, T3, T4>()
         {
@@ -42,16 +60,47 @@ namespace Catel.Reflection
         }
 
         /// <summary>
-        /// Gets an array of type from two type parameters.
+        /// Gets an array of type from four type parameters.
+        /// </summary>
+        /// <param name="type1">The type1</param>
+        /// <param name="type2">The type2</param>
+        /// <param name="type3">The type3</param>
+        /// <param name="type4">The type4</param>
+        /// <returns>Array of types</returns>
+        public static Type[] From(Type type1, Type type2, Type type3, Type type4)
+        {
+            var genericType = typeof(ArrayCache<,,,>).MakeGenericType(type1, type2, type3, type4);
+            var field = genericType.GetFieldEx("Value", BindingFlags.Static | BindingFlags.Public);
+            return (Type[])field.GetValue(genericType);
+        }
+
+
+        /// <summary>
+        /// Gets an array of type from three type parameters.
         /// </summary>
         /// <typeparam name="T1">The type 1</typeparam>
         /// <typeparam name="T2">The type 2</typeparam>
-		/// <typeparam name="T3">The type 3</typeparam>
+        /// <typeparam name="T3">The type 3</typeparam>
         /// <returns>Array of types</returns>
         public static Type[] From<T1, T2, T3>()
         {
             return ArrayCache<T1, T2, T3>.Value;
         }
+
+        /// <summary>
+        /// Gets an array of type from three type parameters.
+        /// </summary>
+        /// <param name="type1">The type1</param>
+        /// <param name="type2">The type2</param>
+        /// <param name="type3">The type3</param>
+        /// <returns>Array of types</returns>
+        public static Type[] From(Type type1, Type type2, Type type3)
+        {
+            var genericType = typeof(ArrayCache<,,>).MakeGenericType(type1, type2, type3);
+            var field = genericType.GetFieldEx("Value", BindingFlags.Static | BindingFlags.Public);
+            return (Type[])field.GetValue(genericType);
+        }
+
 
         /// <summary>
         /// Gets an array of type from two type parameters.
@@ -67,11 +116,37 @@ namespace Catel.Reflection
         /// <summary>
         /// Gets an array of type from two type parameters.
         /// </summary>
+        /// <param name="type1">The type1</param>
+        /// <param name="type2">The type2</param>
+        /// <returns>Array of types</returns>
+        public static Type[] From(Type type1, Type type2)
+        {
+            var genericType = typeof(ArrayCache<,>).MakeGenericType(type1, type2);
+            var field = genericType.GetFieldEx("Value", BindingFlags.Static | BindingFlags.Public);
+            return (Type[])field.GetValue(genericType);
+        }
+
+
+        /// <summary>
+        /// Gets an array of type from two type parameters.
+        /// </summary>
         /// <typeparam name="T">The type</typeparam>
         /// <returns>Array of types</returns>
         public static Type[] From<T>()
         {
             return ArrayCache<T>.Value;
+        }
+
+        /// <summary>
+        /// Gets an array of type from two type parameters.
+        /// </summary>
+        /// <param name="type">The type</param>
+        /// <returns>Array of types</returns>
+        public static Type[] From(Type type)
+        {
+            var genericType = typeof(ArrayCache<>).MakeGenericType(type);
+            var field = genericType.GetFieldEx("Value", BindingFlags.Static | BindingFlags.Public);
+            return (Type[])field.GetValue(genericType);
         }
 
         private static class ArrayCache<T1, T2, T3, T4, T5>

--- a/src/Catel.Core/Catel.Core.Shared/Reflection/TypeCache.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Reflection/TypeCache.cs
@@ -650,7 +650,7 @@ namespace Catel.Reflection
                     _typesWithoutAssemblyLowerCase?.Clear();
                 }
 
-                var assembliesToInitialize = checkSingleAssemblyOnly ? new List<Assembly>(new[] { assembly }) : AssemblyHelper.GetLoadedAssemblies();
+                var assembliesToInitialize = checkSingleAssemblyOnly ? new List<Assembly> { assembly } : AssemblyHelper.GetLoadedAssemblies();
                 InitializeAssemblies(assembliesToInitialize, forceFullInitialization, allowMultithreadedInitialization);
             }
         }

--- a/src/Catel.Core/Catel.Core.Shared/Runtime/Serialization/Modifiers/KeyValuePairSerializerModifier.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Runtime/Serialization/Modifiers/KeyValuePairSerializerModifier.cs
@@ -73,7 +73,7 @@ namespace Catel.Runtime.Serialization
                     var valueValue = splittedValues[4];
 
                     // TODO: consider caching
-                    var keyValuePairGenericType = keyValuePairType.MakeGenericType(keyType, valueType);
+                    var keyValuePairGenericType = keyValuePairType.MakeGenericTypeEx(keyType, valueType);
 
                     var key = StringToObjectHelper.ToRightType(keyType, keyValue);
                     var value = StringToObjectHelper.ToRightType(valueType, valueValue);

--- a/src/Catel.Core/Catel.Core.Shared/Runtime/Serialization/SerializerBase.general.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Runtime/Serialization/SerializerBase.general.cs
@@ -929,7 +929,7 @@ namespace Catel.Runtime.Serialization
             if (elementType != null)
             {
                 var collectionType = typeof(List<>);
-                var genericCollectionType = collectionType.MakeGenericType(elementType);
+                var genericCollectionType = collectionType.MakeGenericTypeEx(elementType);
 
                 type = genericCollectionType;
             }

--- a/src/Catel.Core/Catel.Core.Shared/WeakReferences/WeakAction.cs
+++ b/src/Catel.Core/Catel.Core.Shared/WeakReferences/WeakAction.cs
@@ -104,7 +104,7 @@ namespace Catel
             }
 
             var targetType = (target != null) ? target.GetType() : typeof(object);
-            var delegateType = typeof(OpenInstanceAction<>).MakeGenericType(targetType);
+            var delegateType = typeof(OpenInstanceAction<>).MakeGenericTypeEx(targetType);
 
             _action = DelegateHelper.CreateDelegate(delegateType, methodInfo);
         }
@@ -192,7 +192,7 @@ namespace Catel
             }
 
             var targetType = (target != null) ? target.GetType() : typeof(object);
-            var delegateType = typeof(OpenInstanceGenericAction<>).MakeGenericType(typeof(TParameter), targetType);
+            var delegateType = typeof(OpenInstanceGenericAction<>).MakeGenericTypeEx(typeof(TParameter), targetType);
 
             _action = DelegateHelper.CreateDelegate(delegateType, methodInfo);
         }

--- a/src/Catel.Core/Catel.Core.Shared/WeakReferences/WeakEventListener.cs
+++ b/src/Catel.Core/Catel.Core.Shared/WeakReferences/WeakEventListener.cs
@@ -403,13 +403,13 @@ namespace Catel
             {
                 if (isAction)
                 {
-                    var delegateType = typeof(OpenInstanceActionHandler<>).MakeGenericType(finalTarget.GetType());
+                    var delegateType = typeof(OpenInstanceActionHandler<>).MakeGenericTypeEx(finalTarget.GetType());
                     var del = DelegateHelper.CreateDelegate(delegateType, methodInfo);
                     weakListener.OnEventAction = del;
                 }
                 else
                 {
-                    var delegateType = typeof(OpenInstanceEventHandler<,>).MakeGenericType(finalTarget.GetType(), typeof(TEventArgs));
+                    var delegateType = typeof(OpenInstanceEventHandler<,>).MakeGenericTypeEx(finalTarget.GetType(), typeof(TEventArgs));
                     var del = DelegateHelper.CreateDelegate(delegateType, methodInfo);
                     weakListener.OnEventHandler = del;
                 }
@@ -911,7 +911,7 @@ namespace Catel
             var targetType = typeof(TTarget);
             var sourceType = typeof(TSource);
 
-            MethodInfo methodInfo = null;
+            MethodInfo methodInfo;
 
             var cacheKey = $"{targetType.FullName}_{sourceType.FullName}_{eventArgsType?.FullName}";
 
@@ -919,10 +919,10 @@ namespace Catel
             {
                 if (!ListenerTypeCache.ContainsKey(cacheKey))
                 {
-                    var listenerType = typeof(WeakEventListener<TTarget, TSource, EventArgsBase>).GetGenericTypeDefinition().MakeGenericType(new[] { targetType, sourceType, eventArgsType });
+                    var listenerType = typeof(WeakEventListener<TTarget, TSource, EventArgsBase>).GetGenericTypeDefinition().MakeGenericTypeEx(targetType, sourceType, eventArgsType);
                     var bindingFlags = BindingFlagsHelper.GetFinalBindingFlags(true, true);
 
-                    ListenerTypeCache[cacheKey] = listenerType.GetMethodEx("SubscribeToWeakEventWithExplicitSourceType", new[] { targetType, sourceType, typeof(string), typeof(Delegate), typeof(bool) }, bindingFlags);
+                    ListenerTypeCache[cacheKey] = listenerType.GetMethodEx("SubscribeToWeakEventWithExplicitSourceType", TypeArray.From(targetType, sourceType, typeof(string), typeof(Delegate), typeof(bool)), bindingFlags);
                 }
 
                 methodInfo = ListenerTypeCache[cacheKey];
@@ -1146,10 +1146,10 @@ namespace Catel
             {
                 if (!ListenerTypeCache.ContainsKey(cacheKey))
                 {
-                    var listenerType = typeof(WeakEventListener<object, object>).GetGenericTypeDefinition().MakeGenericType(new[] { targetType, sourceType });
+                    var listenerType = typeof(WeakEventListener<object, object>).GetGenericTypeDefinition().MakeGenericTypeEx(targetType, sourceType);
                     var bindingFlags = BindingFlagsHelper.GetFinalBindingFlags(true, true);
 
-                    ListenerTypeCache[cacheKey] = listenerType.GetMethodEx("SubscribeToWeakEventWithExplicitSourceType", new[] { targetType, sourceType, typeof(string), typeof(Delegate), typeof(bool) }, bindingFlags);
+                    ListenerTypeCache[cacheKey] = listenerType.GetMethodEx("SubscribeToWeakEventWithExplicitSourceType", TypeArray.From(targetType, sourceType, typeof(string), typeof(Delegate), typeof(bool)), bindingFlags);
                 }
 
                 methodInfo = ListenerTypeCache[cacheKey];

--- a/src/Catel.Core/Catel.Core.Shared/WeakReferences/WeakFunc.cs
+++ b/src/Catel.Core/Catel.Core.Shared/WeakReferences/WeakFunc.cs
@@ -54,7 +54,7 @@ namespace Catel
             }
 
             var targetType = target?.GetType() ?? typeof(object);
-            var delegateType = typeof(OpenInstanceAction<>).MakeGenericType(typeof(TResult), targetType);
+            var delegateType = typeof(OpenInstanceAction<>).MakeGenericTypeEx(typeof(TResult), targetType);
 
             _action = DelegateHelper.CreateDelegate(delegateType, methodInfo);
         }
@@ -155,7 +155,7 @@ namespace Catel
             }
 
             var targetType = target?.GetType() ?? typeof(object);
-            var delegateType = typeof(OpenInstanceGenericAction<>).MakeGenericType(typeof(TParameter), typeof(TResult), targetType);
+            var delegateType = typeof(OpenInstanceGenericAction<>).MakeGenericTypeEx(typeof(TParameter), typeof(TResult), targetType);
 
             _action = DelegateHelper.CreateDelegate(delegateType, methodInfo);
         }

--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Converters/EnumToVisibilityConverter.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Converters/EnumToVisibilityConverter.cs
@@ -81,7 +81,7 @@ namespace Catel.MVVM.Converters
                 stringParameter = stringParameter.Substring(1);
             }
 
-            var genericEnumType = typeof(Enum<>).MakeGenericType(enumType);
+            var genericEnumType = typeof(Enum<>).MakeGenericTypeEx(enumType);
             var bindingFlags = BindingFlags.Public | BindingFlags.Static;
             
             var parseMethod = genericEnumType.GetMethodEx("Parse", TypeArray.From<string, bool>(), bindingFlags);

--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Helpers/ViewHelper.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/Helpers/ViewHelper.cs
@@ -71,7 +71,7 @@ namespace Catel.MVVM
             // First, try to constructor directly with the data context
             if (dataContext != null)
             {
-                var injectionConstructor = viewType.GetConstructorEx(new[] { dataContext.GetType() });
+                var injectionConstructor = viewType.GetConstructorEx(TypeArray.From(dataContext.GetType()));
                 if (injectionConstructor != null)
                 {
                     view = (FrameworkElement)injectionConstructor.Invoke(new[] { dataContext });

--- a/src/Catel.Test/Catel.Test.NET45/Catel.Test.NET45.csproj
+++ b/src/Catel.Test/Catel.Test.NET45/Catel.Test.NET45.csproj
@@ -46,6 +46,9 @@
     <Reference Include="Castle.Core, Version=4.1.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\..\lib\Castle.Core.4.1.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
+    <Reference Include="dotMemory.Unit, Version=103.0.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\..\..\lib\JetBrains.dotMemoryUnit.2.3.20160517.113140\Lib\dotMemory.Unit.dll</HintPath>
+    </Reference>
     <Reference Include="MethodTimer, Version=1.19.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\lib\MethodTimer.Fody.1.19.1\lib\netstandard1.0\MethodTimer.dll</HintPath>
     </Reference>

--- a/src/Catel.Test/Catel.Test.NET45/packages.config
+++ b/src/Catel.Test/Catel.Test.NET45/packages.config
@@ -3,6 +3,7 @@
   <package id="AsyncUsageAnalyzers" version="1.0.0-alpha003" targetFramework="net45" developmentDependency="true" />
   <package id="Castle.Core" version="4.1.0" targetFramework="net45" />
   <package id="Fody" version="2.1.2" targetFramework="net45" developmentDependency="true" />
+  <package id="JetBrains.dotMemoryUnit" version="2.3.20160517.113140" targetFramework="net45" />
   <package id="MethodTimer.Fody" version="1.19.1" targetFramework="net45" developmentDependency="true" />
   <package id="ModuleInit.Fody" version="1.6.0" targetFramework="net45" developmentDependency="true" />
   <package id="Moq" version="4.7.63" targetFramework="net45" />

--- a/src/Catel.Test/Catel.Test.Shared/Catel.Test.Shared.projitems
+++ b/src/Catel.Test/Catel.Test.Shared/Catel.Test.Shared.projitems
@@ -238,6 +238,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Reflection\ReflectionExtensionsFacts.methodinfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Reflection\ReflectionExtensionsFacts.propertyinfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Reflection\ReflectionExtensionsFacts.type.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Reflection\TypeArrayFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Reflection\TypeCacheFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Reflection\TypeExtensionsFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Reflection\TypeHelperFacts.cs" />

--- a/src/Catel.Test/Catel.Test.Shared/Reflection/ReflectionExtensionsFacts.type.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Reflection/ReflectionExtensionsFacts.type.cs
@@ -170,37 +170,5 @@ namespace Catel.Test.Reflection
                 Assert.IsNotNull(propertyInfo);
             }
         }
-
-        [TestFixture]
-        public class TheMakeGenericExFacts
-        {
-            class ClassA<T>
-            {
-            }
-
-            [Test]
-            [DotMemoryUnit(CollectAllocations = true)]
-            [Ignore("Requires dotMemory")]
-            public void Allocates_Less_Type_Arrays_Than_MakeGenericType()
-            {
-                int count = int.MaxValue;
-
-                var memoryCheckPoint1 = dotMemory.Check();
-                var makeGenericTypeEx1 = typeof(ClassA<>).MakeGenericTypeEx(typeof(int));
-                var makeGenericTypeEx2 = typeof(ClassA<>).MakeGenericTypeEx(typeof(int));
-                var makeGenericTypeEx3 = typeof(ClassA<>).MakeGenericTypeEx(typeof(int));
-                var makeGenericTypeEx4 = typeof(ClassA<>).MakeGenericTypeEx(typeof(int));
-                var makeGenericTypeEx5 = typeof(ClassA<>).MakeGenericTypeEx(typeof(int));
-                dotMemory.Check(memory => count = memory.GetDifference(memoryCheckPoint1).GetNewObjects(where => where.Type.Is<Type[]>()).ObjectsCount);
-
-                var memoryCheckPoint2 = dotMemory.Check();
-                var makeGenericType1 = typeof(ClassA<>).MakeGenericType(typeof(int));
-                var makeGenericType2 = typeof(ClassA<>).MakeGenericType(typeof(int));
-                var makeGenericType3 = typeof(ClassA<>).MakeGenericType(typeof(int));
-                var makeGenericType4 = typeof(ClassA<>).MakeGenericType(typeof(int));
-                var makeGenericType5 = typeof(ClassA<>).MakeGenericType(typeof(int));
-                dotMemory.Check(memory => Assert.Less(count, memory.GetDifference(memoryCheckPoint2).GetNewObjects(where => where.Type.Is<Type[]>()).ObjectsCount));
-            }
-        }
     }
 }

--- a/src/Catel.Test/Catel.Test.Shared/Reflection/ReflectionExtensionsFacts.type.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Reflection/ReflectionExtensionsFacts.type.cs
@@ -11,6 +11,9 @@ namespace Catel.Test.Reflection
     using System.Runtime.InteropServices;
     using Catel.IoC;
     using Catel.Reflection;
+
+    using JetBrains.dotMemoryUnit;
+
     using NUnit.Framework;
 
     public partial class ReflectionExtensionsFacts
@@ -165,6 +168,38 @@ namespace Catel.Test.Reflection
                 var propertyInfo = typeof(Person).GetPropertyEx("FirstName", allowExplicitInterfaceProperties: true);
 
                 Assert.IsNotNull(propertyInfo);
+            }
+        }
+
+        [TestFixture]
+        public class TheMakeGenericExFacts
+        {
+            class ClassA<T>
+            {
+            }
+
+            [Test]
+            [DotMemoryUnit(CollectAllocations = true)]
+            [Ignore("Requires dotMemory")]
+            public void Allocates_Less_Type_Arrays_Than_MakeGenericType()
+            {
+                int count = int.MaxValue;
+
+                var memoryCheckPoint1 = dotMemory.Check();
+                var makeGenericTypeEx1 = typeof(ClassA<>).MakeGenericTypeEx(typeof(int));
+                var makeGenericTypeEx2 = typeof(ClassA<>).MakeGenericTypeEx(typeof(int));
+                var makeGenericTypeEx3 = typeof(ClassA<>).MakeGenericTypeEx(typeof(int));
+                var makeGenericTypeEx4 = typeof(ClassA<>).MakeGenericTypeEx(typeof(int));
+                var makeGenericTypeEx5 = typeof(ClassA<>).MakeGenericTypeEx(typeof(int));
+                dotMemory.Check(memory => count = memory.GetDifference(memoryCheckPoint1).GetNewObjects(where => where.Type.Is<Type[]>()).ObjectsCount);
+
+                var memoryCheckPoint2 = dotMemory.Check();
+                var makeGenericType1 = typeof(ClassA<>).MakeGenericType(typeof(int));
+                var makeGenericType2 = typeof(ClassA<>).MakeGenericType(typeof(int));
+                var makeGenericType3 = typeof(ClassA<>).MakeGenericType(typeof(int));
+                var makeGenericType4 = typeof(ClassA<>).MakeGenericType(typeof(int));
+                var makeGenericType5 = typeof(ClassA<>).MakeGenericType(typeof(int));
+                dotMemory.Check(memory => Assert.Less(count, memory.GetDifference(memoryCheckPoint2).GetNewObjects(where => where.Type.Is<Type[]>()).ObjectsCount));
             }
         }
     }

--- a/src/Catel.Test/Catel.Test.Shared/Reflection/TypeArrayFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Reflection/TypeArrayFacts.cs
@@ -1,0 +1,53 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="TypeArrayFacts.cs" company="Catel development team">
+//   Copyright (c) 2008 - 2017 Catel development team. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+
+namespace Catel.Test.Reflection
+{
+    using System;
+
+    using Catel.Reflection;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class TypeArrayFacts
+    {
+        [TestFixture]
+        private class The_Generic_From_Method
+        {
+            [Test]
+            public void Returns_The_Same_Type_Array_Instance_Of_The_Non_Generic_Method_Version_1()
+            {
+                Assert.AreSame(TypeArray.From<int>(), TypeArray.From(typeof(int)));
+            }
+
+            [Test]
+            public void Returns_The_Same_Type_Array_Instance_Of_The_Non_Generic_Method_Version_2()
+            {
+                Assert.AreSame(TypeArray.From<int, bool>(), TypeArray.From(typeof(int), typeof(bool)));
+            }
+
+            [Test]
+            public void Returns_The_Same_Type_Array_Instance_Of_The_Non_Generic_Method_Version_3()
+            {
+                Assert.AreSame(TypeArray.From<int, bool, string>(), TypeArray.From(typeof(int), typeof(bool), typeof(string)));
+            }
+
+            [Test]
+            public void Returns_The_Same_Type_Array_Instance_Of_The_Non_Generic_Method_Version_4()
+            {
+                Assert.AreSame(TypeArray.From<int, bool, string, object>(), TypeArray.From(typeof(int), typeof(bool), typeof(string), typeof(object)));
+            }
+
+            [Test]
+            public void Returns_The_Same_Type_Array_Instance_Of_The_Non_Generic_Method_Version_5()
+            {
+                Assert.AreSame(TypeArray.From<int, bool, string, object, Exception>(), TypeArray.From(typeof(int), typeof(bool), typeof(string), typeof(object), typeof(Exception)));
+            }
+        }
+    }
+}

--- a/src/Catel.Test/Catel.Test.Shared/Reflection/TypeExtensionsFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Reflection/TypeExtensionsFacts.cs
@@ -16,6 +16,7 @@ namespace Catel.Test.Reflection
     using Catel.Test.Runtime.Serialization;
 
     using NUnit.Framework;
+    using JetBrains.dotMemoryUnit;
 
     [TestFixture]
     public class TypeExtensionsFacts
@@ -96,6 +97,38 @@ namespace Catel.Test.Reflection
         public void TheGetCollectionElementTypeMethod(Type type, Type expectedElementType)
         {
             Assert.AreEqual(expectedElementType, type.GetCollectionElementType());
+        }
+    }
+
+    [TestFixture]
+    public class TheMakeGenericExMethod
+    {
+        class ClassA<T>
+        {
+        }
+
+        [Test]
+        [DotMemoryUnit(CollectAllocations = true)]
+        [Ignore("Requires dotMemory")]
+        public void Allocates_Less_Type_Arrays_Than_MakeGenericType()
+        {
+            int count = int.MaxValue;
+
+            var memoryCheckPoint1 = dotMemory.Check();
+            var makeGenericTypeEx1 = typeof(ClassA<>).MakeGenericTypeEx(typeof(int));
+            var makeGenericTypeEx2 = typeof(ClassA<>).MakeGenericTypeEx(typeof(int));
+            var makeGenericTypeEx3 = typeof(ClassA<>).MakeGenericTypeEx(typeof(int));
+            var makeGenericTypeEx4 = typeof(ClassA<>).MakeGenericTypeEx(typeof(int));
+            var makeGenericTypeEx5 = typeof(ClassA<>).MakeGenericTypeEx(typeof(int));
+            dotMemory.Check(memory => count = memory.GetDifference(memoryCheckPoint1).GetNewObjects(where => where.Type.Is<Type[]>()).ObjectsCount);
+
+            var memoryCheckPoint2 = dotMemory.Check();
+            var makeGenericType1 = typeof(ClassA<>).MakeGenericType(typeof(int));
+            var makeGenericType2 = typeof(ClassA<>).MakeGenericType(typeof(int));
+            var makeGenericType3 = typeof(ClassA<>).MakeGenericType(typeof(int));
+            var makeGenericType4 = typeof(ClassA<>).MakeGenericType(typeof(int));
+            var makeGenericType5 = typeof(ClassA<>).MakeGenericType(typeof(int));
+            dotMemory.Check(memory => Assert.Less(count, memory.GetDifference(memoryCheckPoint2).GetNewObjects(where => where.Type.Is<Type[]>()).ObjectsCount));
         }
     }
 }


### PR DESCRIPTION
Fixes #940.

### Changes proposed in this pull request:

- Add From method overloads to ArrayType with non-generic parameters in order avoid reallocation of the same type arrays
- Add the MakeGenericTypeEx method in order avoid reallocation of the same type arrays
- Replace the usage of MakeGenericType method in favor of MakeGenericTypeEx  

### Notes

- The usage From non-generic overloads and MakeGenericTypeEx  doesn't warranty fewer allocations it requires the usage of MakeGenericType that allocates the params arrays but warranty the usage of the same array type.

        Assert.AreSame(ArrayType.From<int, bool>(), ArrayType.From(typeof(int), typeof(bool)))

