### PR TITLE
#1115 Changed ViewModelManager.UnregisterAllModels() so that it remov…

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,6 +12,7 @@
 
 Daniel Kühner <daniel.kuehner@gmail.com>
 Geert van Horrik <geert@catenalogic.com>
+Igor Selyakov <is.selyakov@gmail.com>
 Igr Alexánder Fernández Saúco <alexander.fernandez.sauco@gmail.com>
 Mattias Eppler <mattias-eppler@gmx.de>
 Steven Chapman <stev.code@gmail.com>

--- a/doc/history.txt
+++ b/doc/history.txt
@@ -37,7 +37,7 @@ none
 
 Added/fixed:
 ============
-...
+(*) #1115 Changed ViewModelManager.UnregisterAllModels() so that it removes an unnecessary list of models.
 
 Roadmap:
 ========

--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/ViewModels/ViewModelManager.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/ViewModels/ViewModelManager.cs
@@ -203,14 +203,11 @@ namespace Catel.MVVM
 
             lock (_viewModelModelsLock)
             {
-                if (!_viewModelModels.ContainsKey(viewModel.UniqueIdentifier))
+                if (_viewModelModels.TryGetValue(viewModel.UniqueIdentifier, out var models))
                 {
-                    _viewModelModels[viewModel.UniqueIdentifier] = new List<object>();
+                    modelCount = models.Count;
+                    _viewModelModels.Remove(viewModel.UniqueIdentifier);
                 }
-
-                var models = _viewModelModels[viewModel.UniqueIdentifier];
-                modelCount = models.Count;
-                models.Clear();
             }
 
             Log.Debug("Unregistered all '{0}' models of view model '{1}' (id = '{2}')", modelCount, viewModelTypeName, viewModel.UniqueIdentifier);

--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/ViewModels/ViewModelManager.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/ViewModels/ViewModelManager.cs
@@ -173,18 +173,24 @@ namespace Catel.MVVM
 
             Log.Debug("Unregistering model '{0}' with view model '{1}' (id = '{2}')", modelTypeName, viewModelTypeName, viewModel.UniqueIdentifier);
 
+            var modelWasRemoved = false;
+
             lock (_viewModelModelsLock)
             {
-                if (!_viewModelModels.ContainsKey(viewModel.UniqueIdentifier))
+                if (_viewModelModels.TryGetValue(viewModel.UniqueIdentifier, out var models))
                 {
-                    _viewModelModels[viewModel.UniqueIdentifier] = new List<object>();
+                    models.Remove(model);
+                    modelWasRemoved = true;
                 }
-
-                var models = _viewModelModels[viewModel.UniqueIdentifier];
-                models.Remove(model);
             }
 
-            Log.Debug("Unregistered model '{0}' with view model '{1}' (id = '{2}')", modelTypeName, viewModelTypeName, viewModel.UniqueIdentifier);
+            if (modelWasRemoved)
+            {
+                Log.Debug("Unregistered model '{0}' with view model '{1}' (id = '{2}')", modelTypeName, viewModelTypeName, viewModel.UniqueIdentifier);
+                return;
+            }
+
+            Log.Debug("Model '{0}' was not registered with view model '{1}' (id = '{2}') or has already been unregistered.", modelTypeName, viewModelTypeName, viewModel.UniqueIdentifier);
         }
 
         /// <summary>

--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/ViewModels/ViewModelManager.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/ViewModels/ViewModelManager.cs
@@ -187,10 +187,11 @@ namespace Catel.MVVM
             if (modelWasRemoved)
             {
                 Log.Debug("Unregistered model '{0}' with view model '{1}' (id = '{2}')", modelTypeName, viewModelTypeName, viewModel.UniqueIdentifier);
-                return;
             }
-
-            Log.Debug("Model '{0}' was not registered with view model '{1}' (id = '{2}') or has already been unregistered.", modelTypeName, viewModelTypeName, viewModel.UniqueIdentifier);
+            else
+            {
+                Log.Debug("Model '{0}' was not registered with view model '{1}' (id = '{2}') or has already been unregistered.", modelTypeName, viewModelTypeName, viewModel.UniqueIdentifier);
+            }
         }
 
         /// <summary>

--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/ViewModels/ViewModelManager.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/ViewModels/ViewModelManager.cs
@@ -144,12 +144,12 @@ namespace Catel.MVVM
 
             lock (_viewModelModelsLock)
             {
-                if (!_viewModelModels.ContainsKey(viewModel.UniqueIdentifier))
+                if (!_viewModelModels.TryGetValue(viewModel.UniqueIdentifier, out var models))
                 {
-                    _viewModelModels[viewModel.UniqueIdentifier] = new List<object>();
+                    models = new List<object>();
+                    _viewModelModels[viewModel.UniqueIdentifier] = models;
                 }
 
-                var models = _viewModelModels[viewModel.UniqueIdentifier];
                 models.Add(model);
             }
 


### PR DESCRIPTION
…es an unnecessary list of models.

Also replaced ContainsKey + [] to TryGetValue to avoid case when FindItem (private method of Dictionary) was called twice that unnecessary too.

Fixes #1115.

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Removing list of models from _viewModelModels in UnregisterAllModels();
- Using TryGetValue instead of ContainsKey + [];
- Skipping clearing when no models registered.