### PR TITLE
Fix 'model' snippet

### DIFF
--- a/snippets/C#/model.snippet
+++ b/snippets/C#/model.snippet
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <CodeSnippets  xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
     <CodeSnippet Format="1.0.0">
         <Header>
@@ -22,8 +22,12 @@
                 <![CDATA[#if NET
 [Serializable]
 #endif
-public class $name$ : ModelBase<$name$>
+public class $name$ : ModelBase
 {
+    #region Fields
+    #endregion
+
+    #region Constructors
     public $name$()
     { 
     }
@@ -34,7 +38,13 @@ public class $name$ : ModelBase<$name$>
 #endif
     #endregion
 
+    #region Properties
     // TODO: Define your custom properties here using the 'modelprop' code snippet
+    #endregion
+    
+    #region Methods
+
+    #endregion
 }]]>
             </Code>
         </Snippet>


### PR DESCRIPTION
Previous model snippet was broken - for example it had #endregion, but no #region. Also some regions were missing.
ModelBase was put here as generic, which generated errors.

Fixes # .

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

-
-
-
