### PR TITLE
(*) #1127 Use TypeCache instead AppDomain.CurrentDomain in ServiceLocatorDependencyRegistrationManager implementation

### DIFF
--- a/doc/history.txt
+++ b/doc/history.txt
@@ -38,7 +38,7 @@ Classes / members marked as obsolete:
 
 Added/fixed:
 ============
-xxx
+(*) #1127 Use TypeCache instead AppDomain.CurrentDomain in ServiceLocatorDependencyRegistrationManager implementation
 
 Roadmap:
 ========

--- a/src/Catel.MVVM/Catel.MVVM.Xamarin.Forms/IoC/ServiceLocatorDependencyRegistrationManager.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Xamarin.Forms/IoC/ServiceLocatorDependencyRegistrationManager.cs
@@ -59,11 +59,21 @@ namespace Catel.IoC
         /// </summary>
         public void Initialize()
         {
-            AppDomain.CurrentDomain.AssemblyLoad += CurrentDomainOnAssemblyLoad;
+            TypeCache.AssemblyLoaded += TypeCacheOnAssemblyLoaded;
             foreach (var assembly in AppDomain.CurrentDomain.GetLoadedAssemblies())
             {
                 LoadServiceFromAssembly(assembly);
             }
+        }
+
+        /// <summary>
+        /// Called when an assembly is loaded in the <see cref="TypeCache"/>.
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="args">The <see cref="AssemblyLoadedEventArgs" /> instance containing the event data.</param>
+        private void TypeCacheOnAssemblyLoaded(object sender, AssemblyLoadedEventArgs args)
+        {
+            LoadServiceFromAssembly(args.Assembly);
         }
 
         /// <summary>
@@ -85,16 +95,6 @@ namespace Catel.IoC
 
                 _serviceLocator.RegisterType(interfaceType, serviceLocatorRegistration => DependencyServiceGetMethodInfo.MakeGenericMethod(interfaceType).Invoke(typeof(DependencyService), ArrayOfObjectWithSingleNullElement));
             }
-        }
-
-        /// <summary>
-        /// Called when an assembly is loaded in the current <see cref="AppDomain"/>.
-        /// </summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="args">The <see cref="AssemblyLoadEventArgs" /> instance containing the event data.</param>
-        private void CurrentDomainOnAssemblyLoad(object sender, AssemblyLoadEventArgs args)
-        {
-            LoadServiceFromAssembly(args.LoadedAssembly);
         }
     }
 }

--- a/src/Catel.MVVM/Catel.MVVM.Xamarin.Forms/IoC/ServiceLocatorDependencyRegistrationManager.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Xamarin.Forms/IoC/ServiceLocatorDependencyRegistrationManager.cs
@@ -59,7 +59,7 @@ namespace Catel.IoC
         /// </summary>
         public void Initialize()
         {
-            TypeCache.AssemblyLoaded += TypeCacheOnAssemblyLoaded;
+            TypeCache.AssemblyLoaded += OnTypeCacheAssemblyLoaded;
             foreach (var assembly in AppDomain.CurrentDomain.GetLoadedAssemblies())
             {
                 LoadServiceFromAssembly(assembly);
@@ -71,7 +71,7 @@ namespace Catel.IoC
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="args">The <see cref="AssemblyLoadedEventArgs" /> instance containing the event data.</param>
-        private void TypeCacheOnAssemblyLoaded(object sender, AssemblyLoadedEventArgs args)
+        private void OnTypeCacheAssemblyLoaded(object sender, AssemblyLoadedEventArgs args)
         {
             LoadServiceFromAssembly(args.Assembly);
         }


### PR DESCRIPTION
Fixes #1127.

### Checklist

- [X] I have updated the change log

### Changes proposed in this pull request:

- Use TypeCache instead AppDomain.CurrentDomain in ServiceLocatorDependencyRegistrationManager implementation
