### PR TITLE
#1146 Add IObjectIdGenerator interfaces in order to customize the approach to generate id for objects

### DIFF
--- a/doc/history.txt
+++ b/doc/history.txt
@@ -42,6 +42,7 @@ Added/fixed:
 (*) #1127 Use TypeCache instead AppDomain.CurrentDomain in ServiceLocatorDependencyRegistrationManager implementation
 (*) #1143 UserControlLogic should dispose view models if they implement IDispose
 (*) #1144 Improve [Save|Cancel]AndCloseViewModelAsync behavior when calling on an already closing view model
+(*) #1146 Reuse identifiers in UniqueIdentifierHelper #1146
 (x) #1142 LogicBase calls CloseViewModel twice on view model that is already closing
 
 Roadmap:

--- a/src/Catel.Core/Catel.Core.Shared/Catel.Core.Shared.projitems
+++ b/src/Catel.Core/Catel.Core.Shared/Catel.Core.Shared.projitems
@@ -394,8 +394,13 @@
     <Compile Include="$(MSBuildThisFileDirectory)Scoping\EventArgs\ScopeClosedEventArgs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Scoping\ScopeManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\Extensions\IObjectConverterServiceExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Services\GuidObjectIdGenerator.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Services\NumericBasedObjectIdGenerators.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Services\Interfaces\IObjectIdGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\Interfaces\IRollingInMemoryLogService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\Interfaces\IObjectConverterService.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Services\NumericBasedObjectIdGenerator.generic.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Services\ObjectIdGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\RollingInMemoryLogService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\Interfaces\ILanguageService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\Interfaces\ILanguageSource.cs" />

--- a/src/Catel.Core/Catel.Core.Shared/IoC/ServiceLocator.cs
+++ b/src/Catel.Core/Catel.Core.Shared/IoC/ServiceLocator.cs
@@ -826,6 +826,7 @@ namespace Catel.IoC
 
                 registeredTypeInfo = new ServiceLocatorRegistration(serviceType, serviceImplementationType, tag, registrationType,
                     x => (createServiceFunc != null) ? createServiceFunc(x) : CreateServiceInstance(x));
+
                 _registeredTypes[serviceInfo] = registeredTypeInfo;
             }
 
@@ -861,6 +862,12 @@ namespace Catel.IoC
                     var tag = serviceInfo.Tag;
 
                     var instance = registeredTypeInfo.CreateServiceFunc(registeredTypeInfo);
+
+                    if (instance != null && instance is Type)
+                    {
+                        instance = _typeFactory.CreateInstance((Type)instance);
+                    }
+
                     if (instance == null)
                     {
                         ThrowTypeNotRegisteredException(serviceType);

--- a/src/Catel.Core/Catel.Core.Shared/Services/GuidObjectIdGenerator.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Services/GuidObjectIdGenerator.cs
@@ -9,12 +9,12 @@ namespace Catel.Services
     using System;
 
     /// <summary>
-    /// Guid object generator
+    /// Guid object generator.
     /// </summary>
     /// <typeparam name="TObjectType">
     /// The entity type.
     /// </typeparam>
-    public sealed class GuidObjectIdGenerator<TObjectType> : ObjectIdGenerator<TObjectType, Guid> where TObjectType : class
+    public class GuidObjectIdGenerator<TObjectType> : ObjectIdGenerator<TObjectType, Guid> where TObjectType : class
     {
         /// <inheritdoc />
         protected override Guid GenerateUniqueIdentifier()

--- a/src/Catel.Core/Catel.Core.Shared/Services/GuidObjectIdGenerator.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Services/GuidObjectIdGenerator.cs
@@ -1,0 +1,25 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="GuidObjectIdGenerator.cs" company="Catel development team">
+//   Copyright (c) 2008 - 2018 Catel development team. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Catel.Services
+{
+    using System;
+
+    /// <summary>
+    /// Guid object generator
+    /// </summary>
+    /// <typeparam name="TObjectType">
+    /// The entity type.
+    /// </typeparam>
+    public sealed class GuidObjectIdGenerator<TObjectType> : ObjectIdGenerator<TObjectType, Guid> where TObjectType : class
+    {
+        /// <inheritdoc />
+        protected override Guid GenerateUniqueIdentifier()
+        {
+            return Guid.NewGuid();
+        }
+    }
+}

--- a/src/Catel.Core/Catel.Core.Shared/Services/GuidObjectIdGenerator.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Services/GuidObjectIdGenerator.cs
@@ -14,7 +14,7 @@ namespace Catel.Services
     /// <typeparam name="TObjectType">
     /// The entity type.
     /// </typeparam>
-    public class GuidObjectIdGenerator<TObjectType> : ObjectIdGenerator<TObjectType, Guid> where TObjectType : class
+    public class GuidObjectIdGenerator<TObjectType> : ObjectIdGenerator<TObjectType, Guid>
     {
         /// <inheritdoc />
         protected override Guid GenerateUniqueIdentifier()

--- a/src/Catel.Core/Catel.Core.Shared/Services/Interfaces/IObjectIdGenerator.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Services/Interfaces/IObjectIdGenerator.cs
@@ -15,12 +15,6 @@ namespace Catel.Services
         /// <summary>
         /// Gets the unique identifier for the specified type.
         /// </summary>
-        /// <returns>A new unique identifier.</returns>
-        TUniqueIdentifier GetUniqueIdentifier();
-
-        /// <summary>
-        /// Gets the unique identifier for the specified type.
-        /// </summary>
         /// <returns>A new unique identifier but if <paramref name="reuse"/> is <c>true</c> will return a released identifier.</returns>
         TUniqueIdentifier GetUniqueIdentifier(bool reuse);
 

--- a/src/Catel.Core/Catel.Core.Shared/Services/Interfaces/IObjectIdGenerator.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Services/Interfaces/IObjectIdGenerator.cs
@@ -36,7 +36,6 @@ namespace Catel.Services
     /// <typeparam name="TObjectType">The object type</typeparam>
     /// <typeparam name="TUniqueIdentifier">The unique identifier type</typeparam>
     public interface IObjectIdGenerator<TObjectType, TUniqueIdentifier> : IObjectIdGenerator<TUniqueIdentifier>
-        where TObjectType : class 
     {
     }
 }

--- a/src/Catel.Core/Catel.Core.Shared/Services/Interfaces/IObjectIdGenerator.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Services/Interfaces/IObjectIdGenerator.cs
@@ -16,7 +16,7 @@ namespace Catel.Services
         /// Gets the unique identifier for the specified type.
         /// </summary>
         /// <returns>A new unique identifier but if <paramref name="reuse"/> is <c>true</c> will return a released identifier.</returns>
-        TUniqueIdentifier GetUniqueIdentifier(bool reuse);
+        TUniqueIdentifier GetUniqueIdentifier(bool reuse = false);
 
         /// <summary>
         /// Release the unique identifier for the specified type.

--- a/src/Catel.Core/Catel.Core.Shared/Services/Interfaces/IObjectIdGenerator.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Services/Interfaces/IObjectIdGenerator.cs
@@ -1,0 +1,42 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IObjectIdGenerator.cs" company="Catel development team">
+//   Copyright (c) 2008 - 2018 Catel development team. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Catel.Services
+{
+    /// <summary>
+    /// The object id generator service.
+    /// </summary>
+    /// <typeparam name="TUniqueIdentifier">The unique identifier type</typeparam>
+    public interface IObjectIdGenerator<TUniqueIdentifier>
+    {
+        /// <summary>
+        /// Gets the unique identifier for the specified type.
+        /// </summary>
+        /// <returns>A new unique identifier.</returns>
+        TUniqueIdentifier GetUniqueIdentifier();
+
+        /// <summary>
+        /// Gets the unique identifier for the specified type.
+        /// </summary>
+        /// <returns>A new unique identifier but if <paramref name="reuse"/> is <c>true</c> will return a released identifier.</returns>
+        TUniqueIdentifier GetUniqueIdentifier(bool reuse);
+
+        /// <summary>
+        /// Release the unique identifier for the specified type.
+        /// </summary>
+        void ReleaseIdentifier(TUniqueIdentifier identifier);
+    }
+
+    /// <summary>
+    /// The object id generator service.
+    /// </summary>
+    /// <typeparam name="TObjectType">The object type</typeparam>
+    /// <typeparam name="TUniqueIdentifier">The unique identifier type</typeparam>
+    public interface IObjectIdGenerator<TObjectType, TUniqueIdentifier> : IObjectIdGenerator<TUniqueIdentifier>
+        where TObjectType : class 
+    {
+    }
+}

--- a/src/Catel.Core/Catel.Core.Shared/Services/NumericBasedObjectIdGenerator.generic.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Services/NumericBasedObjectIdGenerator.generic.cs
@@ -1,0 +1,21 @@
+﻿namespace Catel.Services
+{
+    /// <summary>
+    /// The numeric based object id generator.
+    /// </summary>
+    /// <typeparam name="TObjectType">The object type.</typeparam>
+    /// <typeparam name="TUniqueIdentifier">The unique identifier type.</typeparam>
+    public abstract class NumericBasedObjectIdGenerator<TObjectType, TUniqueIdentifier> : ObjectIdGenerator<TObjectType, TUniqueIdentifier>
+        where TObjectType : class
+    {
+        static NumericBasedObjectIdGenerator()
+        {
+            Argument.IsValid("TUniqueIdentifier", typeof(TUniqueIdentifier), type => typeof(int).IsAssignableFrom(type) || typeof(long).IsAssignableFrom(type) || typeof(ulong).IsAssignableFrom(type));
+        }
+
+        /// <summary>
+        /// Gets and sets the value.
+        /// </summary>
+        protected static TUniqueIdentifier Value { get; set; } = default(TUniqueIdentifier);
+    }
+}

--- a/src/Catel.Core/Catel.Core.Shared/Services/NumericBasedObjectIdGenerator.generic.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Services/NumericBasedObjectIdGenerator.generic.cs
@@ -1,16 +1,23 @@
-﻿namespace Catel.Services
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="NumericBasedObjectIdGenerator.cs" company="Catel development team">
+//   Copyright (c) 2008 - 2018 Catel development team. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Catel.Services
 {
+    using Catel.Reflection;
+
     /// <summary>
     /// The numeric based object id generator.
     /// </summary>
     /// <typeparam name="TObjectType">The object type.</typeparam>
     /// <typeparam name="TUniqueIdentifier">The unique identifier type.</typeparam>
     public abstract class NumericBasedObjectIdGenerator<TObjectType, TUniqueIdentifier> : ObjectIdGenerator<TObjectType, TUniqueIdentifier>
-        where TObjectType : class
     {
         static NumericBasedObjectIdGenerator()
         {
-            Argument.IsValid("TUniqueIdentifier", typeof(TUniqueIdentifier), type => typeof(int).IsAssignableFrom(type) || typeof(long).IsAssignableFrom(type) || typeof(ulong).IsAssignableFrom(type));
+            Argument.IsValid("TUniqueIdentifier", typeof(TUniqueIdentifier), type => typeof(int).IsAssignableFromEx(type) || typeof(long).IsAssignableFromEx(type) || typeof(ulong).IsAssignableFromEx(type));
         }
 
         /// <summary>

--- a/src/Catel.Core/Catel.Core.Shared/Services/NumericBasedObjectIdGenerators.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Services/NumericBasedObjectIdGenerators.cs
@@ -4,15 +4,16 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
+
 namespace Catel.Services
 {
     /// <summary>
-    /// Integer object generator
+    /// Integer object id generator.
     /// </summary>
     /// <typeparam name="TObjectType">
     /// The object type.
     /// </typeparam>
-    public sealed class IntegerObjectIdGenerator<TObjectType> : NumericBasedObjectIdGenerator<TObjectType, int> where TObjectType : class
+    public sealed class IntegerObjectIdGenerator<TObjectType> : NumericBasedObjectIdGenerator<TObjectType, int>
     {
         /// <inheritdoc />
         protected override int GenerateUniqueIdentifier()
@@ -22,12 +23,12 @@ namespace Catel.Services
     }
 
     /// <summary>
-    /// Long object generator
+    /// Long object id generator.
     /// </summary>
     /// <typeparam name="TObjectType">
     /// The object type.
     /// </typeparam>
-    public sealed class LongObjectIdGenerator<TObjectType> : NumericBasedObjectIdGenerator<TObjectType, long> where TObjectType : class
+    public sealed class LongObjectIdGenerator<TObjectType> : NumericBasedObjectIdGenerator<TObjectType, long>
     {
         /// <inheritdoc />
         protected override long GenerateUniqueIdentifier()
@@ -37,12 +38,12 @@ namespace Catel.Services
     }
 
     /// <summary>
-    /// ULong object generator
+    /// ULong object id generator
     /// </summary>
     /// <typeparam name="TObjectType">
     /// The object type.
     /// </typeparam>
-    public sealed class ULongObjectIdGenerator<TObjectType> : NumericBasedObjectIdGenerator<TObjectType, ulong> where TObjectType : class
+    public sealed class ULongObjectIdGenerator<TObjectType> : NumericBasedObjectIdGenerator<TObjectType, ulong>
     {
         /// <inheritdoc />
         protected override ulong GenerateUniqueIdentifier()

--- a/src/Catel.Core/Catel.Core.Shared/Services/NumericBasedObjectIdGenerators.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Services/NumericBasedObjectIdGenerators.cs
@@ -38,7 +38,7 @@ namespace Catel.Services
     }
 
     /// <summary>
-    /// ULong object id generator
+    /// ULong object id generator.
     /// </summary>
     /// <typeparam name="TObjectType">
     /// The object type.

--- a/src/Catel.Core/Catel.Core.Shared/Services/NumericBasedObjectIdGenerators.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Services/NumericBasedObjectIdGenerators.cs
@@ -1,0 +1,53 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="NumericBasedObjectIdGenerators.cs" company="Catel development team">
+//   Copyright (c) 2008 - 2018 Catel development team. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Catel.Services
+{
+    /// <summary>
+    /// Integer object generator
+    /// </summary>
+    /// <typeparam name="TObjectType">
+    /// The object type.
+    /// </typeparam>
+    public sealed class IntegerObjectIdGenerator<TObjectType> : NumericBasedObjectIdGenerator<TObjectType, int> where TObjectType : class
+    {
+        /// <inheritdoc />
+        protected override int GenerateUniqueIdentifier()
+        {
+            return Value++;
+        }
+    }
+
+    /// <summary>
+    /// Long object generator
+    /// </summary>
+    /// <typeparam name="TObjectType">
+    /// The object type.
+    /// </typeparam>
+    public sealed class LongObjectIdGenerator<TObjectType> : NumericBasedObjectIdGenerator<TObjectType, long> where TObjectType : class
+    {
+        /// <inheritdoc />
+        protected override long GenerateUniqueIdentifier()
+        {
+            return Value++;
+        }
+    }
+
+    /// <summary>
+    /// ULong object generator
+    /// </summary>
+    /// <typeparam name="TObjectType">
+    /// The object type.
+    /// </typeparam>
+    public sealed class ULongObjectIdGenerator<TObjectType> : NumericBasedObjectIdGenerator<TObjectType, ulong> where TObjectType : class
+    {
+        /// <inheritdoc />
+        protected override ulong GenerateUniqueIdentifier()
+        {
+            return Value++;
+        }
+    }
+}

--- a/src/Catel.Core/Catel.Core.Shared/Services/ObjectIdGenerator.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Services/ObjectIdGenerator.cs
@@ -1,0 +1,63 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ObjectIdGenerator.cs" company="Catel development team">
+//   Copyright (c) 2008 - 2018 Catel development team. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Catel.Services
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// The ObjectIdGenerator class.
+    /// </summary>
+    /// <typeparam name="TObjectType">The object type</typeparam>
+    /// <typeparam name="TUniqueIdentifier">The unique identifier type</typeparam>
+    public abstract class ObjectIdGenerator<TObjectType, TUniqueIdentifier> : IObjectIdGenerator<TObjectType, TUniqueIdentifier>
+        where TObjectType : class
+    {
+        private static readonly Queue<TUniqueIdentifier> _releasedUniqueIdentifiers = new Queue<TUniqueIdentifier>();
+
+        private static readonly object _syncObj = new object();
+
+        /// <inheritdoc />
+        public TUniqueIdentifier GetUniqueIdentifier()
+        {
+            lock (_syncObj)
+            {
+                return GenerateUniqueIdentifier();
+            }
+        }
+
+        /// <inheritdoc />
+        public TUniqueIdentifier GetUniqueIdentifier(bool reuse)
+        {
+            lock (_syncObj)
+            {
+                if (reuse && _releasedUniqueIdentifiers.Count > 0)
+                {
+                    return _releasedUniqueIdentifiers.Dequeue();
+                }
+
+                return GenerateUniqueIdentifier();
+            }
+        }
+
+        /// <inheritdoc />
+        public void ReleaseIdentifier(TUniqueIdentifier identifier)
+        {
+            lock (_syncObj)
+            {
+                _releasedUniqueIdentifiers.Enqueue(identifier);
+            }
+        }
+
+        /// <summary>
+        /// Generates the unique identifier.
+        /// </summary>
+        /// <returns>
+        /// The unique identifier.
+        /// </returns>
+        protected abstract TUniqueIdentifier GenerateUniqueIdentifier();
+    }
+}

--- a/src/Catel.Core/Catel.Core.Shared/Services/ObjectIdGenerator.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Services/ObjectIdGenerator.cs
@@ -21,13 +21,7 @@ namespace Catel.Services
         private static readonly object _syncObj = new object();
 
         /// <inheritdoc />
-        public TUniqueIdentifier GetUniqueIdentifier()
-        {
-            return GenerateUniqueIdentifier();
-        }
-
-        /// <inheritdoc />
-        public TUniqueIdentifier GetUniqueIdentifier(bool reuse)
+        public TUniqueIdentifier GetUniqueIdentifier(bool reuse = false)
         {
             if (reuse)
             {

--- a/src/Catel.Core/Catel.Core.Shared/Services/ObjectIdGenerator.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Services/ObjectIdGenerator.cs
@@ -14,7 +14,6 @@ namespace Catel.Services
     /// <typeparam name="TObjectType">The object type</typeparam>
     /// <typeparam name="TUniqueIdentifier">The unique identifier type</typeparam>
     public abstract class ObjectIdGenerator<TObjectType, TUniqueIdentifier> : IObjectIdGenerator<TObjectType, TUniqueIdentifier>
-        where TObjectType : class
     {
         private static readonly Queue<TUniqueIdentifier> _releasedUniqueIdentifiers = new Queue<TUniqueIdentifier>();
 

--- a/src/Catel.Core/Catel.Core.Shared/Services/ObjectIdGenerator.cs
+++ b/src/Catel.Core/Catel.Core.Shared/Services/ObjectIdGenerator.cs
@@ -33,11 +33,7 @@ namespace Catel.Services
             {
                 lock (_syncObj)
                 {
-                    if (_releasedUniqueIdentifiers == null)
-                    {
-                        _releasedUniqueIdentifiers = new Queue<TUniqueIdentifier>();
-                    }
-                    else if (_releasedUniqueIdentifiers.Count > 0)
+                    if (_releasedUniqueIdentifiers != null && _releasedUniqueIdentifiers.Count > 0)
                     {
                         return _releasedUniqueIdentifiers.Dequeue();
                     }

--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/ViewModels/ViewModelBase.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/ViewModels/ViewModelBase.cs
@@ -93,6 +93,14 @@ namespace Catel.MVVM
         private readonly bool _ignoreMultipleModelsWarning;
 
         /// <summary>
+        /// Value indicating whether the identifier will be reused from the relased identifier pool.
+        /// </summary>
+#if NET
+        [field: NonSerialized]
+#endif
+        private readonly bool _reuseIdentifier;
+
+        /// <summary>
         /// Value indicating whether the view model attributes are initialized. 
         /// </summary>
 #if NET
@@ -269,6 +277,8 @@ namespace Catel.MVVM
             {
                 return;
             }
+
+            _reuseIdentifier = reuseIdentifier;
 
             _ignoreMultipleModelsWarning = ignoreMultipleModelsWarning;
 
@@ -1579,7 +1589,10 @@ namespace Catel.MVVM
 
             ViewModelManager.UnregisterViewModelInstance(this);
 
-            _objectIdGenerator.ReleaseIdentifier(UniqueIdentifier);
+            if (_reuseIdentifier)
+            {
+                _objectIdGenerator.ReleaseIdentifier(UniqueIdentifier);
+            }
         }
 #endregion
     }

--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/ViewModels/ViewModelBase.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/ViewModels/ViewModelBase.cs
@@ -190,7 +190,7 @@ namespace Catel.MVVM
         /// <exception cref="ModelNotRegisteredException">A mapped model is not registered.</exception>
         /// <exception cref="PropertyNotFoundInModelException">A mapped model property is not found.</exception>
         protected ViewModelBase()
-            : this(true, false, false)
+            : this(true, false, false, false)
         {
         }
 
@@ -203,10 +203,13 @@ namespace Catel.MVVM
         /// <param name="skipViewModelAttributesInitialization">
         /// if set to <c>true</c>, the initialization will be skipped and must be done manually via <see cref="InitializeViewModelAttributes"/>.
         /// </param>
+        /// <param name="reuseIdentifier">
+        /// if set to <c>true</c>, the identifier will be reused from the relased identifier pool.
+        /// </param>
         /// <exception cref="ModelNotRegisteredException">A mapped model is not registered.</exception>
         /// <exception cref="PropertyNotFoundInModelException">A mapped model property is not found.</exception>
-        protected ViewModelBase(bool supportIEditableObject, bool ignoreMultipleModelsWarning = false, bool skipViewModelAttributesInitialization = false)
-            : this(null, supportIEditableObject, ignoreMultipleModelsWarning, skipViewModelAttributesInitialization)
+        protected ViewModelBase(bool supportIEditableObject, bool ignoreMultipleModelsWarning = false, bool skipViewModelAttributesInitialization = false, bool reuseIdentifier = false)
+            : this(null, supportIEditableObject, ignoreMultipleModelsWarning, skipViewModelAttributesInitialization, reuseIdentifier)
         {
         }
 
@@ -220,10 +223,13 @@ namespace Catel.MVVM
         /// implement the <see cref="IEditableObject"/> interface.</param>
         /// <param name="ignoreMultipleModelsWarning">if set to <c>true</c>, the warning when using multiple models is ignored.</param>
         /// <param name="skipViewModelAttributesInitialization">if set to <c>true</c>, the initialization will be skipped and must be done manually via <see cref="InitializeViewModelAttributes"/>.</param>
+        /// <param name="reuseIdentifier">
+        /// if set to <c>true</c>, the identifier will be reused from the relased identifier pool.
+        /// </param>
         /// <exception cref="ModelNotRegisteredException">A mapped model is not registered.</exception>
         /// <exception cref="PropertyNotFoundInModelException">A mapped model property is not found.</exception>
         protected ViewModelBase(IServiceLocator serviceLocator, bool supportIEditableObject = true, bool ignoreMultipleModelsWarning = false,
-            bool skipViewModelAttributesInitialization = false)
+            bool skipViewModelAttributesInitialization = false, bool reuseIdentifier = false)
         {
             ViewModelConstructionTime = FastDateTime.Now;
 
@@ -248,7 +254,7 @@ namespace Catel.MVVM
             serviceLocator.RegisterTypeIfNotYetRegisteredWithTag(typeof(IObjectIdGenerator<int>), typeof(IntegerObjectIdGenerator<>).MakeGenericType(type), type);
 
             _objectIdGenerator = serviceLocator.ResolveType<IObjectIdGenerator<int>>(type);
-            UniqueIdentifier = _objectIdGenerator.GetUniqueIdentifier();
+            UniqueIdentifier = _objectIdGenerator.GetUniqueIdentifier(reuseIdentifier);
 
             Log.Debug("Creating view model of type '{0}' with unique identifier {1}", type.Name, UniqueIdentifier);
 

--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/ViewModels/ViewModelBase.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/ViewModels/ViewModelBase.cs
@@ -1589,10 +1589,7 @@ namespace Catel.MVVM
 
             ViewModelManager.UnregisterViewModelInstance(this);
 
-            if (_reuseIdentifier)
-            {
-                _objectIdGenerator.ReleaseIdentifier(UniqueIdentifier);
-            }
+            _objectIdGenerator.ReleaseIdentifier(UniqueIdentifier);
         }
 #endregion
     }

--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/ViewModels/ViewModelBase.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/ViewModels/ViewModelBase.cs
@@ -93,14 +93,6 @@ namespace Catel.MVVM
         private readonly bool _ignoreMultipleModelsWarning;
 
         /// <summary>
-        /// Value indicating whether the identifier will be reused from the relased identifier pool.
-        /// </summary>
-#if NET
-        [field: NonSerialized]
-#endif
-        private readonly bool _reuseIdentifier;
-
-        /// <summary>
         /// Value indicating whether the view model attributes are initialized. 
         /// </summary>
 #if NET
@@ -277,8 +269,6 @@ namespace Catel.MVVM
             {
                 return;
             }
-
-            _reuseIdentifier = reuseIdentifier;
 
             _ignoreMultipleModelsWarning = ignoreMultipleModelsWarning;
 

--- a/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/ViewModels/ViewModelBase.cs
+++ b/src/Catel.MVVM/Catel.MVVM.Shared/MVVM/ViewModels/ViewModelBase.cs
@@ -170,7 +170,7 @@ namespace Catel.MVVM
 #endif
         private string _title;
 
-        private readonly IObjectIdGenerator<int> _objectIdGenerator;
+        private IObjectIdGenerator<int> _objectIdGenerator;
         #endregion
 
         #region Constructors
@@ -247,7 +247,7 @@ namespace Catel.MVVM
 
             serviceLocator.RegisterType(typeof(IObjectIdGenerator<int>), x => GetObjectIdGeneratorType(), type, RegistrationType.Singleton, false);
             _objectIdGenerator = serviceLocator.ResolveType<IObjectIdGenerator<int>>(type);
-            UniqueIdentifier = GetObjectId(_objectIdGenerator);
+            UniqueIdentifier = this.GetObjectId(_objectIdGenerator);
 
             Log.Debug("Creating view model of type '{0}' with unique identifier {1}", type.Name, UniqueIdentifier);
 
@@ -281,8 +281,6 @@ namespace Catel.MVVM
             // As a last step, enable the auditors (we don't need change notifications of previous properties, etc)
             AuditingHelper.RegisterViewModel(this);
         }
-
-
         #endregion
 
         #region Events
@@ -1550,7 +1548,7 @@ namespace Catel.MVVM
         /// <returns>The object id generator</returns>
         protected virtual Type GetObjectIdGeneratorType()
         {
-            return typeof(IntegerObjectIdGenerator<>).MakeGenericTypeEx(GetType());
+            return typeof(IntegerObjectIdGenerator<ViewModelBase>);
         }
 
         /// <summary>

--- a/src/Catel.NET45.sln.DotSettings
+++ b/src/Catel.NET45.sln.DotSettings
@@ -15,6 +15,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_WHILE_BRACES_STYLE/@EntryValue">ALWAYS_ADD</s:String>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_CODE/@EntryValue">1</s:Int64>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_DECLARATIONS/@EntryValue">1</s:Int64>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/XmlDocFormatter/IndentTagContent/@EntryValue">DoNotTouch</s:String>
 
@@ -402,9 +403,14 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
   Copyright (c) 2008 - $CURRENT_YEAR$ Catel development team. All rights reserved.&#xD;
 &lt;/copyright&gt;&#xD;
 --------------------------------------------------------------------------------------------------------------------</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EXml_002ECodeStyle_002EFormatSettingsUpgrade_002EXmlMoveToCommonFormatterSettingsUpgrade/@EntryIndexedValue">True</s:Boolean>

--- a/src/Catel.Test/Catel.Test.Shared/Catel.Test.Shared.projitems
+++ b/src/Catel.Test/Catel.Test.Shared/Catel.Test.Shared.projitems
@@ -281,8 +281,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Services\Extensions\IStartupInfoProviderExtensionsFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\Fixtures\LanguageServiceFixture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\Fixtures\StartupInfoProviderFixture.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Services\GuidObjectIdGeneratorFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\LanguageServiceFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\NamingConventionTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Services\NumericBasedObjectIdGeneratorsFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\ViewModelServiceBaseTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Text\StringBuilderExtensionFacts.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Threading\SynchronizationContextFacts.cs" />

--- a/src/Catel.Test/Catel.Test.Shared/Services/GuidObjectIdGeneratorFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Services/GuidObjectIdGeneratorFacts.cs
@@ -9,7 +9,6 @@ namespace Catel.Test.Services
     using System;
 
     using Catel.Services;
-    using Catel.Test.ViewModels;
 
     using NUnit.Framework;
 
@@ -18,11 +17,26 @@ namespace Catel.Test.Services
         [TestFixture]
         public class The_GetUniqueIdentifier_Method
         {
+            public class PersonViewModel2
+            {
+            }
+
+            public class PersonViewModel4
+            {
+            }
+
+            public class PersonViewModel1
+            {
+            }
+
+            public class PersonViewModel3
+            {
+            }
             [Test]
             public void Returns_New_UniqueIdentifier_Even_If_Are_Generated_By_Different_Instances()
             {
-                IObjectIdGenerator<Guid> generator1 = new GuidObjectIdGenerator<PersonViewModel>();
-                IObjectIdGenerator<Guid> generator2 = new GuidObjectIdGenerator<PersonViewModel>();
+                IObjectIdGenerator<Guid> generator1 = new GuidObjectIdGenerator<PersonViewModel1>();
+                IObjectIdGenerator<Guid> generator2 = new GuidObjectIdGenerator<PersonViewModel1>();
 
                 Assert.AreNotEqual(generator1.GetUniqueIdentifier(), generator2.GetUniqueIdentifier());
             }
@@ -30,7 +44,7 @@ namespace Catel.Test.Services
             [Test]
             public void Returns_A_Released_Identifier_If_Requested()
             {
-                IObjectIdGenerator<Guid> generator = new GuidObjectIdGenerator<PersonViewModel>();
+                IObjectIdGenerator<Guid> generator = new GuidObjectIdGenerator<PersonViewModel2>();
                 var uniqueIdentifier = generator.GetUniqueIdentifier();
 
                 generator.ReleaseIdentifier(uniqueIdentifier);
@@ -41,8 +55,8 @@ namespace Catel.Test.Services
             [Test]
             public void Returns_Unique_Identifier_For_DiferentTypes()
             {
-                IObjectIdGenerator<Guid> generator1 = new GuidObjectIdGenerator<PersonViewModel>();
-                IObjectIdGenerator<Guid> generator2 = new GuidObjectIdGenerator<SameNamespacePersonViewModel>();
+                IObjectIdGenerator<Guid> generator1 = new GuidObjectIdGenerator<PersonViewModel3>();
+                IObjectIdGenerator<Guid> generator2 = new GuidObjectIdGenerator<PersonViewModel4>();
 
                 Assert.AreNotEqual(generator1.GetUniqueIdentifier(), generator2.GetUniqueIdentifier());
             }

--- a/src/Catel.Test/Catel.Test.Shared/Services/GuidObjectIdGeneratorFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Services/GuidObjectIdGeneratorFacts.cs
@@ -37,6 +37,15 @@ namespace Catel.Test.Services
 
                 Assert.AreEqual(uniqueIdentifier, generator.GetUniqueIdentifier(true));
             }
+
+            [Test]
+            public void Returns_Unique_Identifier_For_DiferentTypes()
+            {
+                IObjectIdGenerator<Guid> generator1 = new GuidObjectIdGenerator<PersonViewModel>();
+                IObjectIdGenerator<Guid> generator2 = new GuidObjectIdGenerator<SameNamespacePersonViewModel>();
+
+                Assert.AreNotEqual(generator1.GetUniqueIdentifier(), generator2.GetUniqueIdentifier());
+            }
         }
     }
 }

--- a/src/Catel.Test/Catel.Test.Shared/Services/GuidObjectIdGeneratorFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Services/GuidObjectIdGeneratorFacts.cs
@@ -1,0 +1,42 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="GuidObjectIdGeneratorFacts.cs" company="Catel development team">
+//   Copyright (c) 2008 - 2018 Catel development team. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Catel.Test.Services
+{
+    using System;
+
+    using Catel.Services;
+    using Catel.Test.ViewModels;
+
+    using NUnit.Framework;
+
+    public class GuidObjectIdGeneratorFacts
+    {
+        [TestFixture]
+        public class The_GetUniqueIdentifier_Method
+        {
+            [Test]
+            public void Returns_New_UniqueIdentifier_Even_If_Are_Generated_By_Different_Instances()
+            {
+                IObjectIdGenerator<Guid> generator1 = new GuidObjectIdGenerator<PersonViewModel>();
+                IObjectIdGenerator<Guid> generator2 = new GuidObjectIdGenerator<PersonViewModel>();
+
+                Assert.AreNotEqual(generator1.GetUniqueIdentifier(), generator2.GetUniqueIdentifier());
+            }
+
+            [Test]
+            public void Returns_A_Released_Identifier_If_Requested()
+            {
+                IObjectIdGenerator<Guid> generator = new GuidObjectIdGenerator<PersonViewModel>();
+                var uniqueIdentifier = generator.GetUniqueIdentifier();
+
+                generator.ReleaseIdentifier(uniqueIdentifier);
+
+                Assert.AreEqual(uniqueIdentifier, generator.GetUniqueIdentifier(true));
+            }
+        }
+    }
+}

--- a/src/Catel.Test/Catel.Test.Shared/Services/NumericBasedObjectIdGeneratorsFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Services/NumericBasedObjectIdGeneratorsFacts.cs
@@ -35,6 +35,15 @@ namespace Catel.Test.Services
 
                 Assert.AreEqual(uniqueIdentifier, generator.GetUniqueIdentifier(true));
             }
+
+            [Test]
+            public void Returns_Unique_Identifier_For_DiferentTypes()
+            {
+                IObjectIdGenerator<int> generator1 = new IntegerObjectIdGenerator<PersonViewModel>();
+                IObjectIdGenerator<int> generator2 = new IntegerObjectIdGenerator<SameNamespacePersonViewModel>();
+
+                Assert.AreEqual(generator1.GetUniqueIdentifier(), generator2.GetUniqueIdentifier());
+            }
         }
     }
 
@@ -62,6 +71,16 @@ namespace Catel.Test.Services
 
                 Assert.AreEqual(uniqueIdentifier, generator.GetUniqueIdentifier(true));
             }
+
+            [Test]
+            public void Returns_Unique_Identifier_For_DiferentTypes()
+            {
+                IObjectIdGenerator<int> generator1 = new IntegerObjectIdGenerator<PersonViewModel>();
+                IObjectIdGenerator<int> generator2 = new IntegerObjectIdGenerator<SameNamespacePersonViewModel>();
+
+                Assert.AreEqual(generator1.GetUniqueIdentifier(), generator2.GetUniqueIdentifier());
+            }
+
         }
     }
 
@@ -89,6 +108,16 @@ namespace Catel.Test.Services
 
                 Assert.AreEqual(uniqueIdentifier, generator.GetUniqueIdentifier(true));
             }
+
+            [Test]
+            public void Returns_Unique_Identifier_For_DiferentTypes()
+            {
+                IObjectIdGenerator<int> generator1 = new IntegerObjectIdGenerator<PersonViewModel>();
+                IObjectIdGenerator<int> generator2 = new IntegerObjectIdGenerator<SameNamespacePersonViewModel>();
+
+                Assert.AreEqual(generator1.GetUniqueIdentifier(), generator2.GetUniqueIdentifier());
+            }
+
         }
     }
 }

--- a/src/Catel.Test/Catel.Test.Shared/Services/NumericBasedObjectIdGeneratorsFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Services/NumericBasedObjectIdGeneratorsFacts.cs
@@ -4,10 +4,10 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
+
 namespace Catel.Test.Services
 {
     using Catel.Services;
-    using Catel.Test.ViewModels;
 
     using NUnit.Framework;
 
@@ -19,8 +19,8 @@ namespace Catel.Test.Services
             [Test]
             public void Returns_New_UniqueIdentifier_Even_If_Are_Generated_By_Different_Instances()
             {
-                IObjectIdGenerator<int> generator1 = new IntegerObjectIdGenerator<PersonViewModel>();
-                IObjectIdGenerator<int> generator2 = new IntegerObjectIdGenerator<PersonViewModel>();
+                IObjectIdGenerator<int> generator1 = new IntegerObjectIdGenerator<PersonViewModel1>();
+                IObjectIdGenerator<int> generator2 = new IntegerObjectIdGenerator<PersonViewModel1>();
 
                 Assert.AreNotEqual(generator1.GetUniqueIdentifier(), generator2.GetUniqueIdentifier());
             }
@@ -28,7 +28,7 @@ namespace Catel.Test.Services
             [Test]
             public void Returns_A_Released_Identifier_If_Requested()
             {
-                IObjectIdGenerator<int> generator = new IntegerObjectIdGenerator<PersonViewModel>();
+                IObjectIdGenerator<int> generator = new IntegerObjectIdGenerator<PersonViewModel2>();
                 var uniqueIdentifier = generator.GetUniqueIdentifier();
 
                 generator.ReleaseIdentifier(uniqueIdentifier);
@@ -39,24 +39,56 @@ namespace Catel.Test.Services
             [Test]
             public void Returns_Unique_Identifier_For_DiferentTypes()
             {
-                IObjectIdGenerator<int> generator1 = new IntegerObjectIdGenerator<PersonViewModel>();
-                IObjectIdGenerator<int> generator2 = new IntegerObjectIdGenerator<SameNamespacePersonViewModel>();
+                IObjectIdGenerator<int> generator1 = new IntegerObjectIdGenerator<PersonViewModel3>();
+                IObjectIdGenerator<int> generator2 = new IntegerObjectIdGenerator<PersonViewModel4>();
 
                 Assert.AreEqual(generator1.GetUniqueIdentifier(), generator2.GetUniqueIdentifier());
+            }
+
+            public class PersonViewModel2
+            {
+            }
+
+            public class PersonViewModel4
+            {
+            }
+
+            public class PersonViewModel1
+            {
+            }
+
+            public class PersonViewModel3
+            {
             }
         }
     }
 
     public class LongObjectIdGeneratorFacts
     {
+        public class PersonViewModel2
+        {
+        }
+
+        public class PersonViewModel4
+        {
+        }
+
+        public class PersonViewModel1
+        {
+        }
+
+        public class PersonViewModel3
+        {
+        }
+
         [TestFixture]
         public class The_GetUniqueIdentifier_Method
         {
             [Test]
             public void Returns_New_UniqueIdentifier_Even_If_Are_Generated_By_Different_Instances()
             {
-                IObjectIdGenerator<long> generator1 = new LongObjectIdGenerator<PersonViewModel>();
-                IObjectIdGenerator<long> generator2 = new LongObjectIdGenerator<PersonViewModel>();
+                IObjectIdGenerator<long> generator1 = new LongObjectIdGenerator<PersonViewModel1>();
+                IObjectIdGenerator<long> generator2 = new LongObjectIdGenerator<PersonViewModel1>();
 
                 Assert.AreNotEqual(generator1.GetUniqueIdentifier(), generator2.GetUniqueIdentifier());
             }
@@ -64,7 +96,7 @@ namespace Catel.Test.Services
             [Test]
             public void Returns_A_Released_Identifier_If_Requested()
             {
-                IObjectIdGenerator<long> generator = new LongObjectIdGenerator<PersonViewModel>();
+                IObjectIdGenerator<long> generator = new LongObjectIdGenerator<PersonViewModel2>();
                 var uniqueIdentifier = generator.GetUniqueIdentifier();
 
                 generator.ReleaseIdentifier(uniqueIdentifier);
@@ -75,25 +107,40 @@ namespace Catel.Test.Services
             [Test]
             public void Returns_Unique_Identifier_For_DiferentTypes()
             {
-                IObjectIdGenerator<int> generator1 = new IntegerObjectIdGenerator<PersonViewModel>();
-                IObjectIdGenerator<int> generator2 = new IntegerObjectIdGenerator<SameNamespacePersonViewModel>();
+                IObjectIdGenerator<int> generator1 = new IntegerObjectIdGenerator<PersonViewModel3>();
+                IObjectIdGenerator<int> generator2 = new IntegerObjectIdGenerator<PersonViewModel4>();
 
                 Assert.AreEqual(generator1.GetUniqueIdentifier(), generator2.GetUniqueIdentifier());
             }
-
         }
     }
 
     public class ULongObjectIdGeneratorFacts
     {
+        public class PersonViewModel2
+        {
+        }
+
+        public class PersonViewModel4
+        {
+        }
+
+        public class PersonViewModel1
+        {
+        }
+
+        public class PersonViewModel3
+        {
+        }
+
         [TestFixture]
         public class The_GetUniqueIdentifier_Method
         {
             [Test]
             public void Returns_New_UniqueIdentifier_Even_If_Are_Generated_By_Different_Instances()
             {
-                IObjectIdGenerator<ulong> generator1 = new ULongObjectIdGenerator<PersonViewModel>();
-                IObjectIdGenerator<ulong> generator2 = new ULongObjectIdGenerator<PersonViewModel>();
+                IObjectIdGenerator<ulong> generator1 = new ULongObjectIdGenerator<PersonViewModel1>();
+                IObjectIdGenerator<ulong> generator2 = new ULongObjectIdGenerator<PersonViewModel1>();
 
                 Assert.AreNotEqual(generator1.GetUniqueIdentifier(), generator2.GetUniqueIdentifier());
             }
@@ -101,7 +148,7 @@ namespace Catel.Test.Services
             [Test]
             public void Returns_A_Released_Identifier_If_Requested()
             {
-                IObjectIdGenerator<ulong> generator = new ULongObjectIdGenerator<PersonViewModel>();
+                IObjectIdGenerator<ulong> generator = new ULongObjectIdGenerator<PersonViewModel2>();
                 var uniqueIdentifier = generator.GetUniqueIdentifier();
 
                 generator.ReleaseIdentifier(uniqueIdentifier);
@@ -112,12 +159,11 @@ namespace Catel.Test.Services
             [Test]
             public void Returns_Unique_Identifier_For_DiferentTypes()
             {
-                IObjectIdGenerator<int> generator1 = new IntegerObjectIdGenerator<PersonViewModel>();
-                IObjectIdGenerator<int> generator2 = new IntegerObjectIdGenerator<SameNamespacePersonViewModel>();
+                IObjectIdGenerator<int> generator1 = new IntegerObjectIdGenerator<PersonViewModel3>();
+                IObjectIdGenerator<int> generator2 = new IntegerObjectIdGenerator<PersonViewModel4>();
 
                 Assert.AreEqual(generator1.GetUniqueIdentifier(), generator2.GetUniqueIdentifier());
             }
-
         }
     }
 }

--- a/src/Catel.Test/Catel.Test.Shared/Services/NumericBasedObjectIdGeneratorsFacts.cs
+++ b/src/Catel.Test/Catel.Test.Shared/Services/NumericBasedObjectIdGeneratorsFacts.cs
@@ -1,0 +1,94 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="NumericBasedObjectIdGeneratorsFacts.cs" company="Catel development team">
+//   Copyright (c) 2008 - 2018 Catel development team. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Catel.Test.Services
+{
+    using Catel.Services;
+    using Catel.Test.ViewModels;
+
+    using NUnit.Framework;
+
+    public class IntegerObjectIdGeneratorFacts
+    {
+        [TestFixture]
+        public class The_GetUniqueIdentifier_Method
+        {
+            [Test]
+            public void Returns_New_UniqueIdentifier_Even_If_Are_Generated_By_Different_Instances()
+            {
+                IObjectIdGenerator<int> generator1 = new IntegerObjectIdGenerator<PersonViewModel>();
+                IObjectIdGenerator<int> generator2 = new IntegerObjectIdGenerator<PersonViewModel>();
+
+                Assert.AreNotEqual(generator1.GetUniqueIdentifier(), generator2.GetUniqueIdentifier());
+            }
+
+            [Test]
+            public void Returns_A_Released_Identifier_If_Requested()
+            {
+                IObjectIdGenerator<int> generator = new IntegerObjectIdGenerator<PersonViewModel>();
+                var uniqueIdentifier = generator.GetUniqueIdentifier();
+
+                generator.ReleaseIdentifier(uniqueIdentifier);
+
+                Assert.AreEqual(uniqueIdentifier, generator.GetUniqueIdentifier(true));
+            }
+        }
+    }
+
+    public class LongObjectIdGeneratorFacts
+    {
+        [TestFixture]
+        public class The_GetUniqueIdentifier_Method
+        {
+            [Test]
+            public void Returns_New_UniqueIdentifier_Even_If_Are_Generated_By_Different_Instances()
+            {
+                IObjectIdGenerator<long> generator1 = new LongObjectIdGenerator<PersonViewModel>();
+                IObjectIdGenerator<long> generator2 = new LongObjectIdGenerator<PersonViewModel>();
+
+                Assert.AreNotEqual(generator1.GetUniqueIdentifier(), generator2.GetUniqueIdentifier());
+            }
+
+            [Test]
+            public void Returns_A_Released_Identifier_If_Requested()
+            {
+                IObjectIdGenerator<long> generator = new LongObjectIdGenerator<PersonViewModel>();
+                var uniqueIdentifier = generator.GetUniqueIdentifier();
+
+                generator.ReleaseIdentifier(uniqueIdentifier);
+
+                Assert.AreEqual(uniqueIdentifier, generator.GetUniqueIdentifier(true));
+            }
+        }
+    }
+
+    public class ULongObjectIdGeneratorFacts
+    {
+        [TestFixture]
+        public class The_GetUniqueIdentifier_Method
+        {
+            [Test]
+            public void Returns_New_UniqueIdentifier_Even_If_Are_Generated_By_Different_Instances()
+            {
+                IObjectIdGenerator<ulong> generator1 = new ULongObjectIdGenerator<PersonViewModel>();
+                IObjectIdGenerator<ulong> generator2 = new ULongObjectIdGenerator<PersonViewModel>();
+
+                Assert.AreNotEqual(generator1.GetUniqueIdentifier(), generator2.GetUniqueIdentifier());
+            }
+
+            [Test]
+            public void Returns_A_Released_Identifier_If_Requested()
+            {
+                IObjectIdGenerator<ulong> generator = new ULongObjectIdGenerator<PersonViewModel>();
+                var uniqueIdentifier = generator.GetUniqueIdentifier();
+
+                generator.ReleaseIdentifier(uniqueIdentifier);
+
+                Assert.AreEqual(uniqueIdentifier, generator.GetUniqueIdentifier(true));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1146

### Checklist

- [X] I have included examples or tests
- [X] Updated history.txt

### Changes proposed in this pull request:

- Add IObjectIdGenerator interfaces in order to customize the approach to generate id for objects with options to reuse identifiers
- Fix ViewModelBase constructor implementation in order to use IntegerObjectIdGenerator by default
