### PR TITLE
CTL-1302 Implement IDisposable ViewModel Support in WindowLogic

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -10,6 +10,7 @@
 
 # Please keep the list sorted.
 
+Alan Brault <vaecors@visus.io>
 Daniel Kühner <daniel.kuehner@gmail.com>
 Geert van Horrik <geert@catenalogic.com>
 Igor Selyakov <is.selyakov@gmail.com>

--- a/doc/history.txt
+++ b/doc/history.txt
@@ -42,7 +42,7 @@ Classes / members marked as obsolete
 
 Added/fixed
 ===========
-TODO
+(x) #1302 Implement support for disposing of IDisposable ViewModels in WindowLogic
 
 Roadmap
 =======

--- a/src/Catel.MVVM/MVVM/Providers/LogicBase.cs
+++ b/src/Catel.MVVM/MVVM/Providers/LogicBase.cs
@@ -1104,7 +1104,15 @@ namespace Catel.MVVM.Providers
         /// <summary>
         /// Closes the view model.
         /// </summary>
-        public async virtual Task CloseViewModelAsync(bool? result)
+        public virtual Task CloseViewModelAsync(bool? result)
+        {
+            return CloseViewModelAsync(result, false);
+        }
+
+        /// <summary>
+        /// Closes and disposes the view model.
+        /// </summary>
+        public async virtual Task CloseViewModelAsync(bool? result, bool dispose)
         {
             var vm = ViewModel;
             if (vm != null)
@@ -1127,6 +1135,15 @@ namespace Catel.MVVM.Providers
                     if (!isClosing && !vm.IsClosed)
                     {
                         await vm.CloseViewModelAsync(result);
+
+                        if (dispose)
+                        {
+                            var disposable = vm as IDisposable;
+                            if (disposable != null)
+                            {
+                                disposable.Dispose();
+                            }
+                        }
                     }
 
                     ViewModel = null;

--- a/src/Catel.MVVM/MVVM/Providers/UserControlLogic.cs
+++ b/src/Catel.MVVM/MVVM/Providers/UserControlLogic.cs
@@ -747,7 +747,7 @@ namespace Catel.MVVM.Providers
                 if (currentViewModel != null)
                 {
                     var result = GetViewModelResultValueFromUnloadBehavior();
-                    await CloseAndDisposeViewModelAsync(result);
+                    await CloseViewModelAsync(result, true);
                 }
 
                 ViewModel = ConstructViewModelUsingArgumentOrDefaultConstructor(modelToInject);
@@ -756,7 +756,7 @@ namespace Catel.MVVM.Providers
 
         /// <summary>
         /// Gets the view model result value based on the <see cref="UnloadBehavior"/> property so it can be used for
-        /// the <see cref="CloseAndDisposeViewModelAsync"/> method.
+        /// the <see cref="LogicBase.CloseViewModelAsync(bool?)"/> method.
         /// </summary>
         /// <returns>The right value.</returns>
         private bool? GetViewModelResultValueFromUnloadBehavior()
@@ -779,37 +779,6 @@ namespace Catel.MVVM.Providers
             }
 
             return result;
-        }
-
-        /// <summary>
-        /// Closes and disposes the current view model.
-        /// </summary>
-        /// <param name="result"><c>true</c> if the view model should be saved; <c>false</c> if the view model should be canceled; <c>null</c> if it should only be closed.</param>
-        private async Task CloseAndDisposeViewModelAsync(bool? result)
-        {
-            var vm = ViewModel;
-            if (vm != null)
-            {
-                if (result.HasValue)
-                {
-                    if (result.Value)
-                    {
-                        await vm.SaveViewModelAsync();
-                    }
-                    else
-                    {
-                        await vm.CancelViewModelAsync();
-                    }
-                }
-
-                await CloseViewModelAsync(result);
-
-                var disposable = vm as IDisposable;
-                if (disposable != null)
-                {
-                    disposable.Dispose();
-                }
-            }
         }
 
         /// <summary>

--- a/src/Catel.MVVM/MVVM/Providers/UserControlLogic.cs
+++ b/src/Catel.MVVM/MVVM/Providers/UserControlLogic.cs
@@ -747,7 +747,7 @@ namespace Catel.MVVM.Providers
                 if (currentViewModel != null)
                 {
                     var result = GetViewModelResultValueFromUnloadBehavior();
-                    await CloseViewModelAsync(result, true);
+                    await CloseAndDisposeViewModelAsync(result);
                 }
 
                 ViewModel = ConstructViewModelUsingArgumentOrDefaultConstructor(modelToInject);
@@ -756,7 +756,7 @@ namespace Catel.MVVM.Providers
 
         /// <summary>
         /// Gets the view model result value based on the <see cref="UnloadBehavior"/> property so it can be used for
-        /// the <see cref="LogicBase.CloseViewModelAsync(bool?)"/> method.
+        /// the <see cref="CloseAndDisposeViewModelAsync"/> method.
         /// </summary>
         /// <returns>The right value.</returns>
         private bool? GetViewModelResultValueFromUnloadBehavior()
@@ -779,6 +779,31 @@ namespace Catel.MVVM.Providers
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Closes and disposes the current view model.
+        /// </summary>
+        /// <param name="result"><c>true</c> if the view model should be saved; <c>false</c> if the view model should be canceled; <c>null</c> if it should only be closed.</param>
+        private async Task CloseAndDisposeViewModelAsync(bool? result)
+        {
+            var vm = ViewModel;
+            if (vm != null)
+            {
+                if (result.HasValue)
+                {
+                    if (result.Value)
+                    {
+                        await vm.SaveViewModelAsync();
+                    }
+                    else
+                    {
+                        await vm.CancelViewModelAsync();
+                    }
+                }
+
+                await CloseViewModelAsync(result, true);
+            }
         }
 
         /// <summary>

--- a/src/Catel.MVVM/MVVM/Providers/WindowLogic.cs
+++ b/src/Catel.MVVM/MVVM/Providers/WindowLogic.cs
@@ -109,7 +109,7 @@ namespace Catel.MVVM.Providers
             var vm = ViewModel;
             if (vm != null && !vm.IsClosed)
             {
-                await CloseAndDisposeViewModelAsync(null);
+                await CloseViewModelAsync(null, true);
             }
 
             ViewModel = null;

--- a/src/Catel.MVVM/MVVM/Providers/WindowLogic.cs
+++ b/src/Catel.MVVM/MVVM/Providers/WindowLogic.cs
@@ -109,7 +109,7 @@ namespace Catel.MVVM.Providers
             var vm = ViewModel;
             if (vm != null && !vm.IsClosed)
             {
-                await CloseViewModelAsync(null);
+                await CloseAndDisposeViewModelAsync(null);
             }
 
             ViewModel = null;
@@ -183,10 +183,41 @@ namespace Catel.MVVM.Providers
                     Log.Warning("Failed to get the 'DialogResult' property of window type '{0}', using 'null' as dialog result", TargetWindow.GetType().Name);
                 }
 
-                await CloseViewModelAsync(dialogResult);
+                await CloseAndDisposeViewModelAsync(dialogResult);
             }
 
             _targetWindowClosedWeakEventListener.Detach();
+        }
+
+        /// <summary>
+        /// Closes and disposes the current view model.
+        /// </summary>
+        /// <param name="result"><c>true</c> if the view model should be saved; <c>false</c> if the view model should be canceled; <c>null</c> if it should only be closed.</param>
+        private async Task CloseAndDisposeViewModelAsync(bool? result)
+        {
+            var vm = ViewModel;
+            if (vm != null)
+            {
+                if (result.HasValue)
+                {
+                    if (result.Value)
+                    {
+                        await vm.SaveViewModelAsync();
+                    }
+                    else
+                    {
+                        await vm.CancelViewModelAsync();
+                    }
+                }
+
+                await CloseViewModelAsync(result);
+
+                var disposable = vm as IDisposable;
+                if (disposable != null)
+                {
+                    disposable.Dispose();
+                }
+            }
         }
 
         /// <summary>

--- a/src/Catel.MVVM/MVVM/Providers/WindowLogic.cs
+++ b/src/Catel.MVVM/MVVM/Providers/WindowLogic.cs
@@ -183,41 +183,10 @@ namespace Catel.MVVM.Providers
                     Log.Warning("Failed to get the 'DialogResult' property of window type '{0}', using 'null' as dialog result", TargetWindow.GetType().Name);
                 }
 
-                await CloseAndDisposeViewModelAsync(dialogResult);
+                await CloseViewModelAsync(dialogResult, true);
             }
 
             _targetWindowClosedWeakEventListener.Detach();
-        }
-
-        /// <summary>
-        /// Closes and disposes the current view model.
-        /// </summary>
-        /// <param name="result"><c>true</c> if the view model should be saved; <c>false</c> if the view model should be canceled; <c>null</c> if it should only be closed.</param>
-        private async Task CloseAndDisposeViewModelAsync(bool? result)
-        {
-            var vm = ViewModel;
-            if (vm != null)
-            {
-                if (result.HasValue)
-                {
-                    if (result.Value)
-                    {
-                        await vm.SaveViewModelAsync();
-                    }
-                    else
-                    {
-                        await vm.CancelViewModelAsync();
-                    }
-                }
-
-                await CloseViewModelAsync(result);
-
-                var disposable = vm as IDisposable;
-                if (disposable != null)
-                {
-                    disposable.Dispose();
-                }
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
CTL-1302 Implement IDisposable ViewModel Support in WindowLogic

Supports the disposing of an IDisposable ViewModel when a DataWindow is closed.

Fixes #1302 

### Checklist

- [ ] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- WindowLogic implements CloseAndDisposeViewModelAsync method to ensure that IDisposable ViewModels are supported in DataWindow.