### PR TITLE
Set tag on MissingTypeEventArgs

### DIFF
--- a/doc/history.txt
+++ b/doc/history.txt
@@ -46,6 +46,7 @@ Added/fixed
 (+) #1324 Add TypeCacheEvaluator separate to TypeCache to allow customization of already loaded assemblies
 (+) #1329 Add Spanish translation
 (+) #1342 Add Instance property to the TypeInstantiatedEventArgs
+(+) #1344 Set tag when resolving via MissingType event 
 (*) #1337 Don't throw exception in UIVisualizerService when same view is being re-registered multiple times
 (x) #1302 Implement support for disposing of IDisposable ViewModels in WindowLogic
 (x) #1320 Don't check for reflection only assemblies on .NET Core and .NET Standard (throws NotImplementedException)

--- a/src/Catel.Core/IoC/EventArgs/MissingTypeEventArgs.cs
+++ b/src/Catel.Core/IoC/EventArgs/MissingTypeEventArgs.cs
@@ -26,7 +26,8 @@ namespace Catel.IoC
         /// Type of the interface.
         /// </param>
         /// <exception cref="ArgumentNullException">The <paramref name="interfaceType"/> is <c>null</c>.</exception>
-        public MissingTypeEventArgs(Type interfaceType) : this(interfaceType, null)
+        public MissingTypeEventArgs(Type interfaceType) 
+            : this(interfaceType, null)
         {
         }
 

--- a/src/Catel.Core/IoC/EventArgs/MissingTypeEventArgs.cs
+++ b/src/Catel.Core/IoC/EventArgs/MissingTypeEventArgs.cs
@@ -26,14 +26,26 @@ namespace Catel.IoC
         /// Type of the interface.
         /// </param>
         /// <exception cref="ArgumentNullException">The <paramref name="interfaceType"/> is <c>null</c>.</exception>
-        public MissingTypeEventArgs(Type interfaceType)
+        public MissingTypeEventArgs(Type interfaceType) : this(interfaceType, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MissingTypeEventArgs"/> class. 
+        /// </summary>
+        /// <param name="interfaceType">
+        /// Type of the interface.
+        /// </param>
+        /// <param name="tag">a tag</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="interfaceType"/> is <c>null</c>.</exception>
+        public MissingTypeEventArgs(Type interfaceType, object tag)
         {
             Argument.IsNotNull("interfaceType", interfaceType);
 
             InterfaceType = interfaceType;
             RegistrationType = RegistrationType.Singleton;
+            Tag = tag;
         }
-
         #endregion
 
         #region Properties

--- a/src/Catel.Core/IoC/ServiceLocator.cs
+++ b/src/Catel.Core/IoC/ServiceLocator.cs
@@ -257,7 +257,7 @@ namespace Catel.IoC
                 }
 
                 // Last resort
-                if (IsTypeRegisteredByMissingTypeHandler(serviceType))
+                if (IsTypeRegisteredByMissingTypeHandler(serviceType, null))
                 {
                     return true;
                 }
@@ -302,7 +302,7 @@ namespace Catel.IoC
                 // TODO: Can register, 
 
                 // Last resort
-                if (IsTypeRegisteredByMissingTypeHandler(serviceType))
+                if (IsTypeRegisteredByMissingTypeHandler(serviceType, tag))
                 {
                     return true;
                 }
@@ -703,13 +703,14 @@ namespace Catel.IoC
         /// Determines whether the specified service type is registered by missing type handler.
         /// </summary>
         /// <param name="serviceType">The type of the service.</param>
+        /// <param name="tag">Tag to resolve or null</param>
         /// <returns><c>true</c> if the specified service type is registered; otherwise, <c>false</c>.</returns>
-        private bool IsTypeRegisteredByMissingTypeHandler(Type serviceType)
+        private bool IsTypeRegisteredByMissingTypeHandler(Type serviceType, object tag)
         {
             var missingTypeHandler = MissingType;
             if (missingTypeHandler != null)
             {
-                var eventArgs = new MissingTypeEventArgs(serviceType);
+                var eventArgs = new MissingTypeEventArgs(serviceType, tag);
                 missingTypeHandler(this, eventArgs);
 
                 if (eventArgs.ImplementingInstance != null)

--- a/src/Catel.Tests/IoC/EventArgs/MissingTypeEventArgsFacts.cs
+++ b/src/Catel.Tests/IoC/EventArgs/MissingTypeEventArgsFacts.cs
@@ -28,6 +28,94 @@ namespace Catel.Tests.IoC.EventArgs
 
                 Assert.AreEqual(typeof (ITestInterface), eventArgs.InterfaceType);
             }
+
+            [TestCase]
+            public void CanResolveTransientByMissingTypeEventArgsWithTag()
+            {
+                const string Tag = "TAG";
+                var serviceLocator = new ServiceLocator();
+
+                serviceLocator.MissingType += (s, e) =>
+                {
+                    var tagString = (string)e.Tag;
+                    Type instanceType = (tagString == Tag) ? typeof(ClassATag) : typeof(ClassA);
+                    e.ImplementingType = instanceType;
+                    e.RegistrationType = RegistrationType.Transient;
+                };
+
+                var classA = serviceLocator.ResolveType<IInterfaceA>();
+                var classATag = serviceLocator.ResolveType<IInterfaceA>(Tag);
+
+                Assert.IsInstanceOf(typeof(ClassA), classA);
+                Assert.IsInstanceOf(typeof(ClassATag), classATag);
+            }
+
+            [TestCase]
+            public void ResolvedInstancesAreNotSameForTransientWhenResolvedUsingMissingTypeEventWithTag()
+            {
+                const string Tag = "TAG";
+                var serviceLocator = new ServiceLocator();
+                serviceLocator.MissingType += (s, e) =>
+                {
+                    var tagString = (string)e.Tag;
+                    Type instanceType = (tagString == Tag) ? typeof(ClassATag) : typeof(ClassA);
+                    e.ImplementingType = instanceType;
+                    e.RegistrationType = RegistrationType.Transient;
+                };
+
+                var classATag = serviceLocator.ResolveType<IInterfaceA>(Tag);
+                var classATag2 = serviceLocator.ResolveType<IInterfaceA>(Tag);
+
+                Assert.AreNotSame(classATag, classATag2);
+            }
+
+            [TestCase]
+            public void CanResolveSingletonByMissingTypeEventArgsWithTag()
+            {
+                const string Tag = "TAG";
+                var serviceLocator = new ServiceLocator();
+                serviceLocator.MissingType += (s, e) =>
+                {
+                    var tagString = (string)e.Tag;
+                    IInterfaceA instance = (tagString == Tag) ? new ClassATag() as IInterfaceA : new ClassA() as IInterfaceA;
+                    e.ImplementingInstance = instance;
+                    e.RegistrationType = RegistrationType.Singleton;
+                };
+
+                var classA = serviceLocator.ResolveType<IInterfaceA>();
+                var classATag = serviceLocator.ResolveType<IInterfaceA>(Tag);
+
+                Assert.IsInstanceOf(typeof(ClassA), classA);
+                Assert.IsInstanceOf(typeof(ClassATag), classATag);
+            }
+
+            [TestCase]
+            public void ResolvedInstancesAreSameForSingletonWhenResolvedUsingMissingTypeEventWithTag()
+            {
+                const string Tag = "TAG";
+                var serviceLocator = new ServiceLocator();
+                serviceLocator.MissingType += (s, e) =>
+                {
+                    var tagString = (string)e.Tag;
+                    IInterfaceA instance = (tagString == Tag) ? new ClassATag() as IInterfaceA : new ClassA() as IInterfaceA;
+                    e.ImplementingInstance = instance;
+                    e.RegistrationType = RegistrationType.Singleton;
+                };
+
+                var classATag = serviceLocator.ResolveType<IInterfaceA>(Tag);
+                var classATag2 = serviceLocator.ResolveType<IInterfaceA>(Tag);
+
+                Assert.AreSame(classATag, classATag2);
+            }
+
+            public interface IInterfaceA
+            { }
+
+            public class ClassA : IInterfaceA
+            { }
+
+            public class ClassATag : IInterfaceA
+            { }
         }
     }
 }


### PR DESCRIPTION
Previously the Tag property was always null, so MissingType event
handler could only create default instances. This commit sets the Tag
in MissingTypeEventArgs when trying to resolve via MissingType event.

Fixes #1344  .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

The value of the `Tag `property on `MissingTypeEventArgs` is set when trying to resolve using `MissingType` event.