### PR TITLE
Raise TypeInstantiatedEvent when using createServiceFunc

### DIFF
--- a/src/Catel.Core/IoC/ServiceLocator.cs
+++ b/src/Catel.Core/IoC/ServiceLocator.cs
@@ -827,7 +827,7 @@ namespace Catel.IoC
                 Log.Debug("Registering type '{0}' to type '{1}'", serviceType.FullName, serviceImplementationType.FullName);
 
                 registeredTypeInfo = new ServiceLocatorRegistration(serviceType, serviceImplementationType, tag, registrationType,
-                    x => (createServiceFunc != null) ? createServiceFunc(x) : CreateServiceInstance(x));
+                    x => CreateServiceInstanceWrapper(createServiceFunc ?? DefaultCreateServiceFunc, x));
 
                 _registeredTypes[serviceInfo] = registeredTypeInfo;
             }
@@ -890,13 +890,25 @@ namespace Catel.IoC
         }
 
         /// <summary>
-        /// Creates the service instance.
+        /// Default create service function, uses <see cref="_typeFactory"/> to create a service instance.
         /// </summary>
         /// <param name="registration">The registration.</param>
         /// <returns>The service instance.</returns>
-        private object CreateServiceInstance(ServiceLocatorRegistration registration)
+        private object DefaultCreateServiceFunc(ServiceLocatorRegistration registration)
         {
             var instance = _typeFactory.CreateInstanceWithTag(registration.ImplementingType, registration.Tag);
+            return instance;
+        }
+
+        /// <summary>
+        /// Wraps the provided <paramref name="createServiceFunc"/> and raises the TypeInstantiated event with the created service instance.
+        /// </summary>
+        /// <param name="createServiceFunc">A function which creates a service instance.</param>
+        /// <param name="registration">The registration.</param>
+        /// <returns>The service instance.</returns>
+        private object CreateServiceInstanceWrapper(Func<ServiceLocatorRegistration, object> createServiceFunc, ServiceLocatorRegistration registration)
+        {
+            var instance = createServiceFunc(registration);
             if (instance is null)
             {
                 ThrowTypeNotRegisteredException(registration.DeclaringType, "Failed to instantiate the type using the TypeFactory. Check if the required dependencies are registered as well or that the type has a valid constructor that can be used.");

--- a/src/Catel.Tests/IoC/EventArgs/TypeInstantiatedEventArgsFacts.cs
+++ b/src/Catel.Tests/IoC/EventArgs/TypeInstantiatedEventArgsFacts.cs
@@ -27,6 +27,68 @@ namespace Catel.Tests.IoC.EventArgs
                 Assert.IsTrue(ReferenceEquals(resolved, instance));
             }
 
+            [TestCase]
+            public void TypeInstantiatedEventIsRaisedWhenRegisteringSingletonUsingCreateServiceFunc()
+            {
+                int numCalls = 0;
+                bool typeInstantiatedCalled = false;
+                var serviceLocator = new ServiceLocator();
+                serviceLocator.TypeInstantiated += (s, e) => typeInstantiatedCalled = true;
+
+                IInterfaceA createServiceFunc(ServiceLocatorRegistration reg)
+                {
+                    numCalls++;
+                    return new ClassA();
+                }
+
+                serviceLocator.RegisterType<IInterfaceA>(createServiceFunc, RegistrationType.Singleton);
+
+                var resolved = serviceLocator.ResolveType<IInterfaceA>();
+
+                Assert.IsTrue(typeInstantiatedCalled);
+                Assert.AreEqual(1, numCalls);
+                Assert.IsInstanceOf(typeof(ClassA), resolved);
+            }
+
+            [TestCase]
+            public void TypeInstantiatedEventIsRaisedWhenRegisteringTransientUsingCreateServiceFunc()
+            {
+                int numCalls = 0;
+                bool typeInstantiatedCalled = false;
+                var serviceLocator = new ServiceLocator();
+                serviceLocator.TypeInstantiated += (s, e) => typeInstantiatedCalled = true;
+
+                IInterfaceA createServiceFunc(ServiceLocatorRegistration reg)
+                {
+                    numCalls++;
+                    return new ClassA();
+                }
+
+                serviceLocator.RegisterType<IInterfaceA>(createServiceFunc, RegistrationType.Transient);
+
+                var resolved = serviceLocator.ResolveType<IInterfaceA>();
+                var resolved1 = serviceLocator.ResolveType<IInterfaceA>();
+
+                Assert.IsTrue(typeInstantiatedCalled);
+                Assert.AreEqual(2, numCalls);
+                Assert.IsInstanceOf(typeof(ClassA), resolved);
+            }
+
+            [TestCase]
+            public void TypeInstantiatedEventIsRaisedWhenRegisteringWithoutCreateServiceFunc()
+            {
+                var serviceLocator = new ServiceLocator();
+                bool typeInstantiatedCalled = false;
+                serviceLocator.TypeInstantiated += (s, e) => typeInstantiatedCalled = true;
+
+                serviceLocator.RegisterType<IInterfaceA, ClassA>();
+
+                var resolved = serviceLocator.ResolveType<IInterfaceA>();
+
+                Assert.IsTrue(typeInstantiatedCalled);
+                Assert.IsInstanceOf(typeof(ClassA), resolved);
+            }
+
             public interface IInterfaceA
             { }
 


### PR DESCRIPTION
Previously the TypeInstantiatedEvent was not raised when the instance
was created using custom createServiceFunc. This commit adds code to
raise the event in this case.

Fixes #1346 .

### Checklist

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

Raise `TypeInstantiatedEvent` when the service is registered and created using custom `createServiceFunc`.