### PR TITLE
ObservableDictionary implementation

### DIFF
--- a/doc/history.txt
+++ b/doc/history.txt
@@ -29,6 +29,7 @@ Release date
 
 Added/fixed
 ===========
+(+) #1421 ObservableDictionary for supporting UI controls that utilize Dictionaries
 (x) #1408 Logging in TypeFactory uses wrong parameter name
 
 Platform support changes

--- a/src/Catel.MVVM/Collections/Extensions/EnumerableExtensions.cs
+++ b/src/Catel.MVVM/Collections/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,99 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="EnumerableExtensions.cs" company="Catel development team">
+//   Copyright (c) 2008 - 2019 Catel development team. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+
+namespace Catel.Collections
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Extension methods for <see cref="IEnumerable{T}"/> implementations.
+    /// </summary>
+    public static class EnumerableExtensions
+    {
+        /// <summary>
+        /// Creates an <see cref="ObservableDictionary{TKey,TValue}"/> from an <see cref="IEnumerable{T}"/>
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+        /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TElement">The type of the value returned by <paramref name="elementSelector"/>.</typeparam>
+        /// <param name="source">An <see cref="IEnumerable{T}"/> to create an <see cref="ObservableDictionary{TKey,TValue}"/> from.</param>
+        /// <param name="keySelector">A function to extract a key from each element.</param>
+        /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
+        /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
+        /// <returns>An <see cref="ObservableDictionary{TKey,TValue}"/> that contains values of type <typeparamref name="TElement"/> selected from the input sequence.</returns>
+        public static ObservableDictionary<TKey, TElement> ToObservableDictionary<TSource, TKey, TElement>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+        {
+            Argument.IsNotNull(nameof(source), source);
+            Argument.IsNotNull(nameof(keySelector), keySelector);
+            Argument.IsNotNull(nameof(elementSelector), elementSelector);
+
+            ObservableDictionary<TKey, TElement> d = new ObservableDictionary<TKey, TElement>(comparer);
+
+            foreach (TSource element in source)
+            {
+                d.Add(keySelector(element), elementSelector(element));
+            }
+
+            return d;
+        }
+
+        /// <summary>
+        /// Creates an <see cref="ObservableDictionary{TKey,TValue}"/> from an <see cref="IEnumerable{T}"/>
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+        /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
+        /// <typeparam name="TElement">The type of the value returned by <paramref name="elementSelector"/>.</typeparam>
+        /// <param name="source">An <see cref="IEnumerable{T}"/> to create an <see cref="ObservableDictionary{TKey,TValue}"/> from.</param>
+        /// <param name="keySelector">A function to extract a key from each element.</param>
+        /// <param name="elementSelector">A transform function to produce a result element value from each element.</param>
+        /// <returns>An <see cref="ObservableDictionary{TKey,TValue}"/> that contains values of type <typeparamref name="TElement"/> selected from the input sequence.</returns>
+        public static ObservableDictionary<TKey, TElement> ToObservableDictionary<TSource, TKey, TElement>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
+        {
+            return ToObservableDictionary(source, keySelector, elementSelector, null);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="ObservableDictionary{TKey,TValue}"/> from an <see cref="IEnumerable{T}"/>
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+        /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
+        /// <param name="source">An <see cref="IEnumerable{T}"/> to create an <see cref="ObservableDictionary{TKey,TValue}"/> from.</param>
+        /// <param name="keySelector">A function to extract a key from each element.</param>
+        /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
+        /// <returns>An <see cref="ObservableDictionary{TKey,TValue}"/> that contains keys and values.</returns>
+        public static ObservableDictionary<TKey, TSource> ToObservableDictionary<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            return ToObservableDictionary(source, keySelector, IdentityFunction<TSource>.Instance, comparer);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="ObservableDictionary{TKey,TValue}"/> from an <see cref="IEnumerable{T}"/>
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+        /// <typeparam name="TKey">The type of the key returned by <paramref name="keySelector"/>.</typeparam>
+        /// <param name="source">An <see cref="IEnumerable{T}"/> to create an <see cref="ObservableDictionary{TKey,TValue}"/> from.</param>
+        /// <param name="keySelector">A function to extract a key from each element.</param>
+        /// <returns>An <see cref="ObservableDictionary{TKey,TValue}"/> that contains keys and values.</returns>
+        public static ObservableDictionary<TKey, TSource> ToObservableDictionary<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
+        {
+            return ToObservableDictionary(source, keySelector, IdentityFunction<TSource>.Instance, null);
+        }
+
+        internal class IdentityFunction<TElement>
+        {
+            protected IdentityFunction()
+            {
+            }
+
+            public static Func<TElement, TElement> Instance
+            {
+                get { return x => x; }
+            }
+        }
+    }
+}

--- a/src/Catel.MVVM/Collections/ObservableDictionary.cs
+++ b/src/Catel.MVVM/Collections/ObservableDictionary.cs
@@ -474,16 +474,16 @@ namespace Catel.Collections
                 {
                     Insert(tempKey, (TValue)value, append);
                 }
-                catch (InvalidCastException e)
+                catch (InvalidCastException ex)
                 {
-                    Log.Error(e);
+                    Log.Error(ex);
 
                     throw;
                 }
             }
-            catch (InvalidCastException e)
+            catch (InvalidCastException ex)
             {
-                Log.Error(e);
+                Log.Error(ex);
 
                 throw;
             }

--- a/src/Catel.MVVM/Collections/ObservableDictionary.cs
+++ b/src/Catel.MVVM/Collections/ObservableDictionary.cs
@@ -152,7 +152,7 @@ namespace Catel.Collections
         /// <inheritdoc cref="IDeserializationCallback.OnDeserialization"/>
         public void OnDeserialization(object sender)
         {
-            if (_serializationInfo == null)
+            if (_serializationInfo is null)
             {
                 return;
             }
@@ -359,11 +359,24 @@ namespace Catel.Collections
         /// <inheritdoc cref="IDictionary{TKey, TValue}.TryGetValue"/>
         public bool TryGetValue(TKey key, out TValue value)
         {
-            bool result = _collection.Contains(key);
+#if NETCORE
+            if (!_collection.TryGetValue(key, out KeyValuePair<TKey,> item))
+            {
+                value = default;
+
+                return false;
+            }
+
+            value = item.Value;
+
+            return true;
+#else
+            result = _collection.Contains(key);
 
             value = result ? _collection[key].Value : default;
 
             return result;
+#endif
         }
 
         /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
@@ -406,8 +419,6 @@ namespace Catel.Collections
 
         private static bool IsCompatibleKey(object key)
         {
-            Argument.IsNotNull(nameof(key), key);
-
             return key is TKey;
         }
 
@@ -450,7 +461,7 @@ namespace Catel.Collections
 
         private void InsertObject(object key, object value, bool append)
         {
-            if (value == null && default(TValue) != null)
+            if (value is null && default(TValue) != null)
             {
                 throw Log.ErrorAndCreateException<ArgumentNullException>("Argument '{0}' cannot be null.", nameof(value));
             }

--- a/src/Catel.MVVM/Collections/ObservableDictionary.cs
+++ b/src/Catel.MVVM/Collections/ObservableDictionary.cs
@@ -1,0 +1,682 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ObservableDictionary.cs" company="Catel development team">
+//   Copyright (c) 2008 - 2019 Catel development team. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+
+namespace Catel.Collections
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Collections.Specialized;
+    using System.ComponentModel;
+    using System.Linq;
+    using System.Runtime.Serialization;
+    using IoC;
+    using Logging;
+    using Services;
+
+    internal class IndexedKeyedCollection<TKey, TValue> : KeyedCollection<TKey, KeyValuePair<TKey, TValue>>
+    {
+        public IndexedKeyedCollection()
+        {
+        }
+
+        public IndexedKeyedCollection(IEqualityComparer<TKey> comparer)
+            : base(comparer)
+        {
+        }
+
+        protected override TKey GetKeyForItem(KeyValuePair<TKey, TValue> item)
+        {
+            return item.Key;
+        }
+    }
+
+    /// <summary>
+    /// Represents an observable collection of keys and values.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
+    /// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
+#if NET || NETCORE
+    [Serializable]
+#endif
+    public class ObservableDictionary<TKey, TValue> : IDictionary<TKey, TValue>,
+        IDictionary,
+        IReadOnlyDictionary<TKey, TValue>,
+        ISerializable,
+        IDeserializationCallback,
+        INotifyCollectionChanged,
+        INotifyPropertyChanged
+    {
+        private static readonly ILog Log = LogManager.GetCurrentClassLogger();
+
+        private readonly IndexedKeyedCollection<TKey, TValue> _collection;
+
+        private readonly Lazy<IDispatcherService> _dispatcherService = new Lazy<IDispatcherService>(() => IoCConfiguration.DefaultDependencyResolver.Resolve<IDispatcherService>());
+
+#if NET || NETCORE
+        [field: NonSerialized]
+#endif
+        private readonly SerializationInfo _serializationInfo;
+
+        private Dictionary<TKey, TValue> _dictionaryCache;
+
+        private int _dictionaryCacheVersion;
+
+        private int _version;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ObservableDictionary{TKey,TValue}"/> class that is empty, has the default initial capacity, and uses the default equality comparer for the key type.
+        /// </summary>
+        public ObservableDictionary()
+            : this(new Dictionary<TKey, TValue>(), null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ObservableDictionary{TKey,TValue}"/> class that is empty, has the default initial capacity, and uses the specified <see cref="IEqualityComparer{T}"/>.
+        /// </summary>
+        /// <param name="comparer">The <see cref="IEqualityComparer{T}"/> implementation to use when comparing keys, or <see langword="null" /> to use the default <see cref="IEqualityComparer{T}"/> for the type of key.</param>
+        public ObservableDictionary(IEqualityComparer<TKey> comparer)
+            : this(new Dictionary<TKey, TValue>(), comparer)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ObservableDictionary{TKey,TValue}"/> class that contains elements copied from the specified <see cref="IDictionary{TKey,TValue}"/> and uses the default equality comparer for the key type.
+        /// </summary>
+        /// <param name="dictionary">The <see cref="IDictionary{TKey,TValue}"/> whose elements are copied to the new <see cref="ObservableDictionary{TKey,TValue}"/>.</param>
+        public ObservableDictionary(IDictionary<TKey, TValue> dictionary)
+            : this(dictionary, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ObservableDictionary{TKey,TValue}"/> class that contains elements copied from the specified <see cref="IDictionary{TKey,TValue}"/> and uses the specified <see cref="IEqualityComparer{T}"/>.
+        /// </summary>
+        /// <param name="dictionary">The <see cref="IDictionary{TKey,TValue}"/> whose elements are copied to the new <see cref="ObservableDictionary{TKey,TValue}"/>.</param>
+        /// <param name="comparer">The <see cref="IEqualityComparer{T}"/> implementation to use when comparing keys, or <see langword="null" /> to use the default <see cref="IEqualityComparer{T}"/> for the type of key.</param>
+        public ObservableDictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey> comparer)
+        {
+            Argument.IsNotNull(nameof(dictionary), dictionary);
+
+            Comparer = comparer ?? EqualityComparer<TKey>.Default;
+            _collection = new IndexedKeyedCollection<TKey, TValue>(Comparer);
+
+            foreach (KeyValuePair<TKey, TValue> pair in dictionary)
+            {
+                Add(pair.Key, pair.Value);
+            }
+        }
+
+        protected ObservableDictionary(SerializationInfo info, StreamingContext context)
+        {
+            _serializationInfo = info;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether events should automatically be dispatched to the UI thread.
+        /// </summary>
+        /// <value><c>true</c> if events should automatically be dispatched to the UI thread; otherwise, <c>false</c>.</value>
+        public bool AutomaticallyDispatchChangeNotifications { get; set; } = true;
+
+        /// <see cref="Dictionary{TKey,TValue}.Comparer"/>>
+        public IEqualityComparer<TKey> Comparer { get; }
+
+        /// <inheritdoc cref="Dictionary{TKey, TValue}.KeyCollection"/>
+        public Dictionary<TKey, TValue>.KeyCollection Keys => Dictionary.Keys;
+
+        /// <inheritdoc cref="Dictionary{TKey, TValue}.ValueCollection"/>
+        public Dictionary<TKey, TValue>.ValueCollection Values => Dictionary.Values;
+
+        private Dictionary<TKey, TValue> Dictionary
+        {
+            get
+            {
+                if (_dictionaryCache != null && _dictionaryCacheVersion == _version)
+                {
+                    return _dictionaryCache;
+                }
+
+                _dictionaryCache = _collection.ToDictionary(d => d.Key, d => d.Value);
+                _dictionaryCacheVersion = _version;
+
+                return _dictionaryCache;
+            }
+        }
+
+        /// <inheritdoc cref="IDeserializationCallback.OnDeserialization"/>
+        public void OnDeserialization(object sender)
+        {
+            if (_serializationInfo == null)
+            {
+                return;
+            }
+
+            Collection<KeyValuePair<TKey, TValue>> entries =
+                (Collection<KeyValuePair<TKey, TValue>>)_serializationInfo.GetValue(nameof(entries), typeof(Collection<KeyValuePair<TKey, TValue>>));
+
+            foreach (KeyValuePair<TKey, TValue> keyValuePair in entries)
+            {
+                Add(keyValuePair.Key, keyValuePair.Value);
+            }
+        }
+
+        /// <inheritdoc cref="IDictionary.IsFixedSize"/>
+        public bool IsFixedSize => false;
+
+        /// <inheritdoc cref="ICollection.IsSynchronized"/>
+        public bool IsSynchronized => ((ICollection)_collection).IsSynchronized;
+
+        /// <inheritdoc cref="ICollection.SyncRoot"/>
+        public object SyncRoot => ((ICollection)_collection).SyncRoot;
+
+        /// <inheritdoc cref="IDictionary.Keys"/>
+        ICollection IDictionary.Keys => Dictionary.Keys;
+
+        /// <inheritdoc cref="IDictionary.Values"/>
+        ICollection IDictionary.Values => Dictionary.Values;
+
+        /// <summary>
+        /// Gets or sets the value with the specified key.
+        /// </summary>
+        /// <param name="key">The key of the value to get.</param>
+        /// <returns>The value associated with the specified key, or <see langword="null" /> if <paramref name="key"/> is not in the dictionary or <paramref name="key"/> is of a type that is not assignable to the key of type <typeparamref name="TKey"/> of the <see cref="ObservableDictionary{TKey,TValue}"/>.</returns>
+        public object this[object key]
+        {
+            get
+            {
+                if (IsCompatibleKey(key))
+                {
+                    return _collection[(TKey)key].Value;
+                }
+
+                return null;
+            }
+            set => InsertObject(key, value, false);
+        }
+
+        /// <inheritdoc cref="IDictionary.Add"/>
+        public void Add(object key, object value)
+        {
+            InsertObject(key, value, false);
+        }
+
+        /// <inheritdoc cref="IDictionary.Contains"/>
+        public bool Contains(object key)
+        {
+            if (IsCompatibleKey(key))
+            {
+                return _collection.Contains((TKey)key);
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc cref="ICollection.CopyTo"/>
+        public void CopyTo(Array array, int index)
+        {
+            ((ICollection)_collection).CopyTo(array, index);
+        }
+
+        /// <inheritdoc cref="IDictionary.GetEnumerator"/>
+        IDictionaryEnumerator IDictionary.GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        /// <inheritdoc cref="IDictionary.Remove"/>
+        void IDictionary.Remove(object key)
+        {
+            if (IsCompatibleKey(key))
+            {
+                Remove((TKey)key);
+            }
+        }
+
+        /// <inheritdoc cref="ICollection.Count"/>
+        public int Count => _collection.Count;
+
+        /// <inheritdoc cref="IDictionary.IsReadOnly"/>
+        public bool IsReadOnly => false;
+
+        /// <inheritdoc cref="IDictionary{TKey, TValue}.Keys"/>
+        ICollection<TKey> IDictionary<TKey, TValue>.Keys => Dictionary.Keys;
+
+        /// <inheritdoc cref="IDictionary{TKey, TValue}.Values"/>
+        ICollection<TValue> IDictionary<TKey, TValue>.Values => Dictionary.Values;
+
+        /// <summary>
+        /// Gets or sets the value associated with the specified key.
+        /// </summary>
+        /// <param name="key">The key of the value to get or set</param>
+        /// <returns>The value associated with the specified key. If the specified key is not found, a get operation throws a <see cref="KeyNotFoundException" />, and a set operation creates a new element with the specified key.</returns>
+        public TValue this[TKey key]
+        {
+            get => _collection[key].Value;
+            set => Insert(key, value, false);
+        }
+
+        /// <inheritdoc cref="IDictionary{TKey, TValue}.Add(TKey, TValue)"/>
+        public void Add(TKey key, TValue value)
+        {
+            Insert(key, value, true);
+        }
+
+        /// <inheritdoc cref="ICollection{T}.Add"/>
+        public void Add(KeyValuePair<TKey, TValue> item)
+        {
+            Add(item.Key, item.Value);
+        }
+
+        /// <inheritdoc cref="IDictionary.Clear"/>
+        public void Clear()
+        {
+            if (Count <= 0)
+            {
+                return;
+            }
+
+            _collection.Clear();
+            _version++;
+
+            OnPropertyChanged();
+            OnCollectionChanged();
+        }
+
+        /// <inheritdoc cref="ICollection{T}.Contains"/>
+        public bool Contains(KeyValuePair<TKey, TValue> item)
+        {
+            return _collection.Contains(item);
+        }
+
+        /// <inheritdoc cref="IDictionary{TKey, TValue}.ContainsKey"/>
+        public bool ContainsKey(TKey key)
+        {
+            return _collection.Contains(key);
+        }
+
+        /// <inheritdoc cref="ICollection{T}.CopyTo"/>
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            Argument.IsNotNull(nameof(array), array);
+            Argument.IsNotOutOfRange(nameof(arrayIndex), arrayIndex, 0, array.Length);
+
+            if (array.Rank != 1)
+            {
+                throw Log.ErrorAndCreateException<ArgumentException>("Multidimensional arrays are not supported.");
+            }
+
+            if (array.GetLowerBound(0) != 0)
+            {
+                throw Log.ErrorAndCreateException<ArgumentException>("Array is non-zero lower bound.");
+            }
+
+            if (array.Length - arrayIndex < _collection.Count)
+            {
+                throw Log.ErrorAndCreateException<ArgumentException>("Supplied array was too small.");
+            }
+
+            foreach (KeyValuePair<TKey, TValue> keyValuePair in _collection)
+            {
+                array[arrayIndex++] = new KeyValuePair<TKey, TValue>(keyValuePair.Key, keyValuePair.Value);
+            }
+        }
+
+        /// <inheritdoc cref="IEnumerable{T}.GetEnumerator"/>
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        /// <inheritdoc cref="IDictionary{TKey, TValue}.Remove(TKey)"/>
+        public bool Remove(TKey key)
+        {
+            if (!TryGetValue(key, out TValue value))
+            {
+                return false;
+            }
+
+            KeyValuePair<TKey, TValue> item = new KeyValuePair<TKey, TValue>(key, value);
+            int index = _collection.IndexOf(item);
+
+            if (!_collection.Remove(key))
+            {
+                return false;
+            }
+
+            OnCollectionChanged(NotifyCollectionChangedAction.Remove, item, index);
+
+            _version++;
+
+            return true;
+        }
+
+        /// <inheritdoc cref="IDictionary{TKey, TValue}.TryGetValue"/>
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            bool result = _collection.Contains(key);
+
+            value = result ? _collection[key].Value : default;
+
+            return result;
+        }
+
+        /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        /// <inheritdoc cref="ICollection{T}.Remove"/>
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item)
+        {
+            return Remove(item.Key);
+        }
+
+        /// <inheritdoc cref="INotifyCollectionChanged.CollectionChanged"/>
+        public event NotifyCollectionChangedEventHandler CollectionChanged;
+
+        /// <inheritdoc cref="INotifyPropertyChanged.PropertyChanged"/>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <inheritdoc cref="IReadOnlyDictionary{TKey, TValue}.Keys"/>
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Dictionary.Keys;
+
+        /// <inheritdoc cref="IReadOnlyDictionary{TKey, TValue}.Values"/>
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Dictionary.Values;
+
+        /// <inheritdoc cref="ISerializable.GetObjectData"/>
+        public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            Argument.IsNotNull(nameof(info), info);
+
+            Collection<KeyValuePair<TKey, TValue>> entries = new Collection<KeyValuePair<TKey, TValue>>();
+            foreach (KeyValuePair<TKey, TValue> item in _collection)
+            {
+                entries.Add(item);
+            }
+
+            info.AddValue(nameof(entries), entries);
+        }
+
+        private static bool IsCompatibleKey(object key)
+        {
+            Argument.IsNotNull(nameof(key), key);
+
+            return key is TKey;
+        }
+
+        private void Insert(TKey key, TValue value, bool append)
+        {
+            KeyValuePair<TKey, TValue> newItem = new KeyValuePair<TKey, TValue>(key, value);
+
+            if (TryGetValue(key, out TValue oldValue))
+            {
+                if (append)
+                {
+                    throw Log.ErrorAndCreateException<ArgumentException>("An item with the same key has already been added.");
+                }
+
+                if (Equals(oldValue, value))
+                {
+                    return;
+                }
+
+                KeyValuePair<TKey, TValue> oldItem = new KeyValuePair<TKey, TValue>(key, oldValue);
+                int index = _collection.IndexOf(oldItem);
+
+                _collection.Remove(key);
+                _collection.Insert(index, newItem);
+
+                _version++;
+
+                OnCollectionChanged(NotifyCollectionChangedAction.Replace, newItem, oldItem, index);
+            }
+            else
+            {
+                _collection.Add(new KeyValuePair<TKey, TValue>(key, value));
+                _version++;
+
+                int index = _collection.IndexOf(newItem);
+
+                OnCollectionChanged(NotifyCollectionChangedAction.Add, newItem, index);
+            }
+        }
+
+        private void InsertObject(object key, object value, bool append)
+        {
+            if (value == null && default(TValue) != null)
+            {
+                throw Log.ErrorAndCreateException<ArgumentNullException>("Argument '{0}' cannot be null.", nameof(value));
+            }
+
+            try
+            {
+                TKey tempKey = (TKey)key;
+
+                try
+                {
+                    Insert(tempKey, (TValue)value, append);
+                }
+                catch (InvalidCastException e)
+                {
+                    Log.Error(e);
+
+                    throw;
+                }
+            }
+            catch (InvalidCastException e)
+            {
+                Log.Error(e);
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Raises the <see cref="INotifyCollectionChanged.CollectionChanged"/> event while also ensuring that it is dispatched to the UI thread.
+        /// <remarks>Set <see cref="AutomaticallyDispatchChangeNotifications"/> to <c>false</c> if you do not wish to dispatch to the UI.</remarks>
+        /// </summary>
+        protected virtual void OnCollectionChanged()
+        {
+            OnPropertyChanged();
+
+            if (AutomaticallyDispatchChangeNotifications)
+            {
+                _dispatcherService.Value.BeginInvokeIfRequired(() => CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset)));
+            }
+            else
+            {
+                CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+            }
+        }
+
+        /// <summary>
+        /// Raises the <see cref="INotifyCollectionChanged.CollectionChanged"/> event while also ensuring that it is dispatched to the UI thread.
+        /// </summary>
+        /// <remarks>Set <see cref="AutomaticallyDispatchChangeNotifications"/> to <c>false</c> if you do not wish to dispatch to the UI.</remarks>
+        /// <param name="action">The <see cref="NotifyCollectionChangedAction"/> operation that was executed.</param>
+        /// <param name="changedItem">The updated item.</param>
+        /// <param name="index">The index value of the updated item.</param>
+        protected virtual void OnCollectionChanged(NotifyCollectionChangedAction action, KeyValuePair<TKey, TValue> changedItem, int index)
+        {
+            OnPropertyChanged();
+
+            if (AutomaticallyDispatchChangeNotifications)
+            {
+                _dispatcherService.Value.BeginInvokeIfRequired(() => CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(action, changedItem, index)));
+            }
+            else
+            {
+                CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(action, changedItem, index));
+            }
+        }
+
+        /// <summary>
+        /// Raises the <see cref="INotifyCollectionChanged.CollectionChanged"/> event while also ensuring that it is dispatched to the UI thread.
+        /// </summary>
+        /// <remarks>Set <see cref="AutomaticallyDispatchChangeNotifications"/> to <c>false</c> if you do not wish to dispatch to the UI.</remarks>
+        /// <param name="action">The <see cref="NotifyCollectionChangedAction"/> operation that was executed.</param>
+        /// <param name="newItem">The new item.</param>
+        /// <param name="oldItem">The old item.</param>
+        /// <param name="index">The index value of the old item affected.</param>
+        protected virtual void OnCollectionChanged(NotifyCollectionChangedAction action, KeyValuePair<TKey, TValue> newItem, KeyValuePair<TKey, TValue> oldItem, int index)
+        {
+            OnPropertyChanged();
+
+            if (AutomaticallyDispatchChangeNotifications)
+            {
+                _dispatcherService.Value.BeginInvokeIfRequired(() => CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(action, newItem, oldItem, index)));
+            }
+            else
+            {
+                CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(action, newItem, oldItem, index));
+            }
+        }
+
+        private void OnPropertyChanged()
+        {
+            OnPropertyChanged(nameof(Count));
+            OnPropertyChanged("Item[]");
+            OnPropertyChanged(nameof(Keys));
+            OnPropertyChanged(nameof(Values));
+        }
+
+        /// <summary>
+        /// Raises the <see cref="INotifyPropertyChanged.PropertyChanged"/> event while also ensuring that it is dispatched to the UI thread.
+        /// </summary>
+        /// <remarks>Set <see cref="AutomaticallyDispatchChangeNotifications"/> to <c>false</c> if you do not wish to dispatch to the UI.</remarks>
+        /// <param name="propertyName">The target property to invoke <see cref="INotifyPropertyChanged.PropertyChanged"/> on.</param>
+        protected virtual void OnPropertyChanged(string propertyName)
+        {
+            if (AutomaticallyDispatchChangeNotifications)
+            {
+                _dispatcherService.Value.BeginInvokeIfRequired(() => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName)));
+            }
+            else
+            {
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            }
+        }
+
+#if NET || NETCORE
+        [Serializable]
+#endif
+        public struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>, IDictionaryEnumerator
+        {
+            private readonly ObservableDictionary<TKey, TValue> _dictionary;
+
+            private readonly int _version;
+
+            private KeyValuePair<TKey, TValue> _current;
+
+            private int _index;
+
+            internal Enumerator(ObservableDictionary<TKey, TValue> dictionary)
+            {
+                _dictionary = dictionary;
+                _version = dictionary._version;
+                _index = -1;
+                _current = new KeyValuePair<TKey, TValue>();
+            }
+
+            public KeyValuePair<TKey, TValue> Current
+            {
+                get
+                {
+                    CheckEnumerator();
+
+                    return _current;
+                }
+            }
+
+            public DictionaryEntry Entry
+            {
+                get
+                {
+                    CheckEnumerator();
+
+                    return new DictionaryEntry(_current.Key, _current.Value);
+                }
+            }
+
+            public object Key
+            {
+                get
+                {
+                    CheckEnumerator();
+
+                    return _current.Key;
+                }
+            }
+
+            public object Value
+            {
+                get
+                {
+                    CheckEnumerator();
+
+                    return _current.Value;
+                }
+            }
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose()
+            {
+                // No Managed Resources
+            }
+
+            public bool MoveNext()
+            {
+                CheckVersion();
+
+                _index++;
+
+                if (_index < _dictionary._collection.Count)
+                {
+                    _current = new KeyValuePair<TKey, TValue>(_dictionary._collection[_index].Key, _dictionary._collection[_index].Value);
+
+                    return true;
+                }
+
+                _index = -2;
+                _current = new KeyValuePair<TKey, TValue>();
+
+                return false;
+            }
+
+            public void Reset()
+            {
+                CheckVersion();
+
+                _index = -1;
+                _current = new KeyValuePair<TKey, TValue>();
+            }
+
+            private void CheckEnumerator()
+            {
+                switch (_index)
+                {
+                    case -1:
+                        throw new InvalidOperationException("The enumerator has not been started.");
+                    case -2:
+                        throw new InvalidOperationException("The enumerator has reached the end of the collection.");
+                }
+            }
+
+            private void CheckVersion()
+            {
+                if (_version != _dictionary._version)
+                {
+                    throw new InvalidOperationException("Collection was modified; enumeration operation may not execute.");
+                }
+            }
+        }
+    }
+}

--- a/src/Catel.Tests/Catel.MVVM.approved.cs
+++ b/src/Catel.Tests/Catel.MVVM.approved.cs
@@ -66,6 +66,13 @@ namespace Catel
 }
 namespace Catel.Collections
 {
+    public class static EnumerableExtensions
+    {
+        public static Catel.Collections.ObservableDictionary<TKey, TElement> ToObservableDictionary<TSource, TKey, TElement>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TElement> elementSelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
+        public static Catel.Collections.ObservableDictionary<TKey, TElement> ToObservableDictionary<TSource, TKey, TElement>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Func<TSource, TElement> elementSelector) { }
+        public static Catel.Collections.ObservableDictionary<TKey, TSource> ToObservableDictionary<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
+        public static Catel.Collections.ObservableDictionary<TKey, TSource> ToObservableDictionary<TSource, TKey>(this System.Collections.Generic.IEnumerable<TSource> source, System.Func<TSource, TKey> keySelector) { }
+    }
     public class ExtendedSuspensionContext<T>
     {
         public ExtendedSuspensionContext(Catel.Collections.SuspensionMode mode) { }
@@ -185,6 +192,55 @@ namespace Catel.Collections
         public int NewStartingIndex { get; }
         public System.Collections.IList OldItems { get; }
         public int OldStartingIndex { get; }
+    }
+    public class ObservableDictionary<TKey, TValue> : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IDictionary<TKey, TValue>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>, System.Collections.ICollection, System.Collections.IDictionary, System.Collections.IEnumerable, System.Collections.Specialized.INotifyCollectionChanged, System.ComponentModel.INotifyPropertyChanged, System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
+    {
+        public ObservableDictionary() { }
+        public ObservableDictionary(System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
+        public ObservableDictionary(System.Collections.Generic.IDictionary<TKey, TValue> dictionary) { }
+        public ObservableDictionary(System.Collections.Generic.IDictionary<TKey, TValue> dictionary, System.Collections.Generic.IEqualityComparer<TKey> comparer) { }
+        protected ObservableDictionary(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public bool AutomaticallyDispatchChangeNotifications { get; set; }
+        public System.Collections.Generic.IEqualityComparer<TKey> Comparer { get; }
+        public int Count { get; }
+        public bool IsFixedSize { get; }
+        public bool IsReadOnly { get; }
+        public bool IsSynchronized { get; }
+        public object this[object key] { get; set; }
+        public TValue this[TKey key] { get; set; }
+        public System.Collections.Generic.Dictionary<TKey, TValue>.KeyCollection Keys { get; }
+        public object SyncRoot { get; }
+        public System.Collections.Generic.Dictionary<TKey, TValue>.ValueCollection Values { get; }
+        public event System.Collections.Specialized.NotifyCollectionChangedEventHandler CollectionChanged;
+        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        public void Add(object key, object value) { }
+        public void Add(TKey key, TValue value) { }
+        public void Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
+        public void Clear() { }
+        public bool Contains(object key) { }
+        public bool Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> item) { }
+        public bool ContainsKey(TKey key) { }
+        public void CopyTo(System.Array array, int index) { }
+        public void CopyTo(System.Collections.Generic.KeyValuePair<, >[] array, int arrayIndex) { }
+        public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> GetEnumerator() { }
+        public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        protected virtual void OnCollectionChanged() { }
+        protected virtual void OnCollectionChanged(System.Collections.Specialized.NotifyCollectionChangedAction action, System.Collections.Generic.KeyValuePair<TKey, TValue> changedItem, int index) { }
+        protected virtual void OnCollectionChanged(System.Collections.Specialized.NotifyCollectionChangedAction action, System.Collections.Generic.KeyValuePair<TKey, TValue> newItem, System.Collections.Generic.KeyValuePair<TKey, TValue> oldItem, int index) { }
+        public void OnDeserialization(object sender) { }
+        protected virtual void OnPropertyChanged(string propertyName) { }
+        public bool Remove(TKey key) { }
+        public bool TryGetValue(TKey key, out TValue value) { }
+        public struct Enumerator<TKey, TValue> : System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IDictionaryEnumerator, System.Collections.IEnumerator, System.IDisposable
+        {
+            public System.Collections.Generic.KeyValuePair<TKey, TValue> Current { get; }
+            public System.Collections.DictionaryEntry Entry { get; }
+            public object Key { get; }
+            public object Value { get; }
+            public void Dispose() { }
+            public bool MoveNext() { }
+            public void Reset() { }
+        }
     }
 }
 namespace Catel.Data

--- a/src/Catel.Tests/Collections/EnumerableExtensionsFacts.cs
+++ b/src/Catel.Tests/Collections/EnumerableExtensionsFacts.cs
@@ -1,0 +1,72 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="EnumerableExtensionsFacts.cs" company="Catel development team">
+//   Copyright (c) 2008 - 2019 Catel development team. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Catel.Tests.Collections
+{
+    using System;
+    using System.Collections.Generic;
+    using Catel.Collections;
+    using NUnit.Framework;
+
+    public class EnumerableExtensionsFacts
+    {
+        [TestFixture]
+        public class TheToObservableDictionaryMethod
+        {
+            [Test]
+            public void ReturnsDefault()
+            {
+                var items = new List<KeyValuePair<int, int>>()
+                {
+                    {
+                        new KeyValuePair<int, int>(1, 1)
+                    }
+                };
+
+                var observableDictionary = items.ToObservableDictionary(d => d.Key, d => d.Value);
+
+                var success = observableDictionary.Contains(items[0]);
+
+                Assert.IsTrue(success);
+            }
+
+            [Test]
+            public void ReturnsDefaultWithOnlyKeySelector()
+            {
+                var items = new List<KeyValuePair<int, int>>()
+                {
+                    {
+                        new KeyValuePair<int, int>(1, 1)
+                    }
+                };
+
+                var observableDictionary = items.ToObservableDictionary(d => d.Key);
+
+                var success = observableDictionary.Contains(new KeyValuePair<int, KeyValuePair<int, int>>(1, items[0]));
+
+                Assert.IsTrue(success);
+            }
+
+            [Test]
+            public void ReturnsDefaultWithComparer()
+            {
+                var items = new List<KeyValuePair<string, int>>()
+                {
+                    {
+                        new KeyValuePair<string, int>("Foo", 1)
+                    }
+                };
+
+                var observableDictionary = items.ToObservableDictionary(d => d.Key, d => d.Value, StringComparer.OrdinalIgnoreCase);
+
+                var hasItem = observableDictionary.Contains(items[0]);
+                var comparerWorks = observableDictionary.ContainsKey("foo");
+
+                Assert.IsTrue(hasItem && comparerWorks);
+            }
+        }
+    }
+}

--- a/src/Catel.Tests/Collections/ObservableDictionaryFacts.cs
+++ b/src/Catel.Tests/Collections/ObservableDictionaryFacts.cs
@@ -1,0 +1,473 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ObservableDictionaryFacts.cs" company="Catel development team">
+//   Copyright (c) 2008 - 2019 Catel development team. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+
+namespace Catel.Tests.Collections
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Specialized;
+    using Catel.Collections;
+    using NUnit.Framework;
+
+    public class ObservableDictionaryFacts
+    {
+        [TestFixture]
+        public class TheConstructor
+        {
+            [Test]
+            public void ThrowsArgumentNullExceptionForNullCollection()
+            {
+                Assert.That(() => new ObservableDictionary<object, object>(null, null), Throws.ArgumentNullException);
+            }
+
+            [Test]
+            public void ReturnsDefaultComparer()
+            {
+                var defaultComparer = EqualityComparer<int>.Default;
+
+                var observableDictionary = new ObservableDictionary<int, int>()
+                {
+                    {
+                        1, 1
+                    }
+                };
+
+                Assert.AreEqual(defaultComparer, observableDictionary.Comparer);
+            }
+
+            [Test]
+            public void ReturnsCustomComparer()
+            {
+                var customComparer = StringComparer.OrdinalIgnoreCase;
+
+                var observableDictionary = new ObservableDictionary<string, int>(customComparer)
+                {
+                    {
+                        "1", 1
+                    }
+                };
+
+                Assert.AreEqual(customComparer, observableDictionary.Comparer);
+            }
+        }
+
+        [TestFixture]
+        public class TheAddMethod
+        {
+            [Test]
+            public void ThrowsInvalidCastExceptionForAddObject()
+            {
+                var observableDictionary = new ObservableDictionary<int, int>();
+
+                Assert.That(() => observableDictionary.Add((object)"1", 1), Throws.TypeOf<InvalidCastException>());
+            }
+
+            [Test]
+            public void ThrowsArgumentNullExceptionForAddObject()
+            {
+                var observableDictionary = new ObservableDictionary<int, int>();
+
+                Assert.That(() => observableDictionary.Add(1, null), Throws.ArgumentNullException);
+            }
+
+            [Test]
+            public void RaisesEventWhileAddingKvp()
+            {
+                var counter = 0;
+                var observableDictionary = new ObservableDictionary<int, int>();
+
+                observableDictionary.AutomaticallyDispatchChangeNotifications = false;
+                observableDictionary.CollectionChanged += (sender, args) => counter++;
+
+                observableDictionary.Add(new KeyValuePair<int, int>(1, 1));
+                Assert.AreEqual(1, counter);
+
+                observableDictionary.Add(new KeyValuePair<int, int>(2, 2));
+                Assert.AreEqual(2, counter);
+
+                observableDictionary.Add(new KeyValuePair<int, int>(3, 3));
+                Assert.AreEqual(3, counter);
+
+                observableDictionary.Add(new KeyValuePair<int, int>(4, 4));
+                Assert.AreEqual(4, counter);
+            }
+
+            [Test]
+            public void RaisesEventWhileAddingObject()
+            {
+                var counter = 0;
+                var observableDictionary = new ObservableDictionary<int, int>();
+
+                observableDictionary.AutomaticallyDispatchChangeNotifications = false;
+                observableDictionary.CollectionChanged += (sender, args) => counter++;
+
+                observableDictionary.Add((object)1, (object)1);
+                Assert.AreEqual(1, counter);
+
+                observableDictionary.Add((object)2, (object)2);
+                Assert.AreEqual(2, counter);
+
+                observableDictionary.Add((object)3, (object)3);
+                Assert.AreEqual(3, counter);
+
+                observableDictionary.Add((object)4, (object)4);
+                Assert.AreEqual(4, counter);
+            }
+
+            [Test]
+            public void RaiseEventWhileAddingStronglyTyped()
+            {
+                var counter = 0;
+                var observableDictionary = new ObservableDictionary<int, int>();
+
+                observableDictionary.AutomaticallyDispatchChangeNotifications = false;
+                observableDictionary.CollectionChanged += (sender, args) => counter++;
+
+                observableDictionary.Add(1, 1);
+                Assert.AreEqual(1, counter);
+
+                observableDictionary.Add(2, 2);
+                Assert.AreEqual(2, counter);
+
+                observableDictionary.Add(3, 3);
+                Assert.AreEqual(3, counter);
+
+                observableDictionary.Add(4, 4);
+                Assert.AreEqual(4, counter);
+            }
+        }
+
+        [TestFixture]
+        public class TheClearMethod
+        {
+            [Test]
+            public void RaisesEventWhileClearing()
+            {
+                bool wasRaised = false;
+                var observableDictionary = new ObservableDictionary<int, int>
+                {
+                    {
+                        1, 1
+                    }
+                };
+
+                observableDictionary.AutomaticallyDispatchChangeNotifications = false;
+                observableDictionary.CollectionChanged += (sender, args) => wasRaised = args.Action == NotifyCollectionChangedAction.Reset;
+
+                observableDictionary.Clear();
+
+                Assert.IsTrue(wasRaised && observableDictionary.Count == 0);
+            }
+        }
+
+        [TestFixture]
+        public class TheContainsMethod
+        {
+            [Test]
+            public void ContainsKvpSuccess()
+            {
+                var observableDictionary = new ObservableDictionary<int, int>()
+                {
+                    {
+                        1, 2
+                    }
+                };
+
+                var result = observableDictionary.Contains(new KeyValuePair<int, int>(1, 2));
+
+                Assert.IsTrue(result);
+            }
+
+            [Test]
+            public void ContainsObjectTrue()
+            {
+                var observableDictionary = new ObservableDictionary<int, int>()
+                {
+                    {
+                        1, 2
+                    }
+                };
+
+                var result = observableDictionary.Contains((object)1);
+
+                Assert.IsTrue(result);
+            }
+
+            [Test]
+            public void ContainsObjectFalse()
+            {
+                var observableDictionary = new ObservableDictionary<int, int>()
+                {
+                    {
+                        1, 2
+                    }
+                };
+
+                var result = observableDictionary.Contains((object)2);
+
+                Assert.IsFalse(result);
+            }
+
+            [Test]
+            public void ContainsObjectInvalidTypeFalse()
+            {
+                var observableDictionary = new ObservableDictionary<int, int>()
+                {
+                    {
+                        1, 2
+                    }
+                };
+
+                var result = observableDictionary.Contains((object)"1");
+
+                Assert.IsFalse(result);
+            }
+        }
+
+        [TestFixture]
+        public class TheContainsKeyMethod
+        {
+            [Test]
+            public void ContainsKeyTrue()
+            {
+                var observableDictionary = new ObservableDictionary<int, int>()
+                {
+                    {
+                        1, 1
+                    }
+                };
+
+                var success = observableDictionary.ContainsKey(1);
+
+                Assert.IsTrue(success);
+            }
+
+            [Test]
+            public void ContainsKeyFalse()
+            {
+                var observableDictionary = new ObservableDictionary<int, int>()
+                {
+                    {
+                        1, 1
+                    }
+                };
+
+                var success = observableDictionary.ContainsKey(2);
+
+                Assert.IsFalse(success);
+            }
+        }
+
+        [TestFixture]
+        public class TheCopyToMethod
+        {
+            [Test]
+            public void PopulatesArray()
+            {
+                Array arr = new KeyValuePair<int, int>[2];
+
+                var observableDictionary = new ObservableDictionary<int, int>()
+                {
+                    {
+                        1, 1
+                    },
+                    {
+                        2, 2
+                    }
+                };
+
+                observableDictionary.CopyTo(arr, 0);
+
+                Assert.IsTrue(arr.Length == 2);
+            }
+            [Test]
+            public void PopulatesKvpArray()
+            {
+                KeyValuePair<int, int>[] arr = new KeyValuePair<int, int>[2];
+
+                var observableDictionary = new ObservableDictionary<int, int>()
+                {
+                    {
+                        1, 1
+                    },
+                    {
+                        2, 2
+                    }
+                };
+
+                observableDictionary.CopyTo(arr, 0);
+
+                Assert.IsTrue(arr.Length == 2);
+            }
+        }
+
+        [TestFixture]
+        public class TheIndexer
+        {
+            [Test]
+            public void ThrowsInvalidCastExceptionForAddingObject()
+            {
+                var observableDictionary = new ObservableDictionary<int, int>();
+
+                Assert.That(() => observableDictionary[(object)"1"] = 1, Throws.TypeOf<InvalidCastException>());
+            }
+
+            [Test]
+            public void RaisesEventWhileAddingObject()
+            {
+                var counter = 0;
+                var observableDictionary = new ObservableDictionary<int, int>();
+
+                observableDictionary.AutomaticallyDispatchChangeNotifications = false;
+                observableDictionary.CollectionChanged += (sender, args) => counter++;
+
+                observableDictionary[(object)1] = 1;
+                Assert.AreEqual(1, counter);
+
+                observableDictionary[(object)2] = 2;
+                Assert.AreEqual(2, counter);
+
+                observableDictionary[(object)3] = 3;
+                Assert.AreEqual(3, counter);
+
+                observableDictionary[(object)4] = 4;
+                Assert.AreEqual(4, counter);
+            }
+
+            [Test]
+            public void RaisesEventWhileAddingStronglyTyped()
+            {
+                var counter = 0;
+                var observableDictionary = new ObservableDictionary<int, int>();
+
+                observableDictionary.AutomaticallyDispatchChangeNotifications = false;
+                observableDictionary.CollectionChanged += (sender, args) => counter++;
+
+                observableDictionary[1] = 1;
+                Assert.AreEqual(1, counter);
+
+                observableDictionary[2] = 2;
+                Assert.AreEqual(2, counter);
+
+                observableDictionary[3] = 3;
+                Assert.AreEqual(3, counter);
+
+                observableDictionary[4] = 4;
+                Assert.AreEqual(4, counter);
+            }
+
+            [Test]
+            public void RaisesEventWhileUpdatingObject()
+            {
+                var isUpdated = false;
+                var observableDictionary = new ObservableDictionary<int, int>()
+                {
+                    {
+                        1, 1
+                    }
+                };
+
+                observableDictionary.AutomaticallyDispatchChangeNotifications = false;
+                observableDictionary.CollectionChanged += (sender, args) => isUpdated = args.Action == NotifyCollectionChangedAction.Replace;
+
+                observableDictionary[(object)1] = 3;
+
+                Assert.IsTrue(isUpdated);
+            }
+
+            [Test]
+            public void RaisesEventWhileUpdatingStronglyTyped()
+            {
+                var isUpdated = false;
+                var observableDictionary = new ObservableDictionary<int, int>()
+                {
+                    {
+                        1, 1
+                    }
+                };
+
+                observableDictionary.AutomaticallyDispatchChangeNotifications = false;
+                observableDictionary.CollectionChanged += (sender, args) => isUpdated = args.Action == NotifyCollectionChangedAction.Replace;
+
+                observableDictionary[1] = 3;
+
+                Assert.IsTrue(isUpdated);
+            }
+
+            [Test]
+            public void ReturnsNullForInvalidTypedObject()
+            {
+                var observableDictionary = new ObservableDictionary<int, int>()
+                {
+                    {
+                        1, 1
+                    }
+                };
+
+                var result = observableDictionary[(object)"1"];
+
+                Assert.IsNull(result);
+            }
+        }
+
+        [TestFixture]
+        public class TheRemoveMethod
+        {
+            [Test]
+            public void RaiseEventWhileRemovingStronglyTyped()
+            {
+                var counter = 1;
+                var observableDictionary = new ObservableDictionary<int, int>
+                {
+                    {
+                        1, 1
+                    }
+                };
+
+                observableDictionary.AutomaticallyDispatchChangeNotifications = false;
+                observableDictionary.CollectionChanged += (sender, args) => counter--;
+
+                observableDictionary.Remove(1);
+                Assert.AreEqual(0, counter);
+            }
+        }
+
+        [TestFixture]
+        public class TheTryGetValueMethod
+        {
+            [Test]
+            public void ReturnsValueFromValidKey()
+            {
+                var observableDictionary = new ObservableDictionary<int, int>
+                {
+                    {
+                        1, 1
+                    }
+                };
+
+                var success = observableDictionary.TryGetValue(1, out int value);
+
+                Assert.IsTrue(success && value == 1);
+            }
+
+            [Test]
+            public void ReturnsDefaultFromInvalidKey()
+            {
+                var observableDictionary = new ObservableDictionary<int, int>
+                {
+                    {
+                        1, 1
+                    }
+                };
+
+                var success = observableDictionary.TryGetValue(2, out int value);
+
+                Assert.IsTrue(!success && value == 0);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###

Implements a dictionary with support for INotifyCollectionChanged and INotifyPropertyChanged called ObservableDictionary. Also supports serialization.

### Issues Resolved ### 
- fixes #1421 

### API Changes ###

- Catel.Collections.ObservableCollection
- Catel.Collections.EnumerableExtensions.ToObservableDictionary()
- Catel.Tests.Collections.ObservableDictionaryFacts
- Catel.Tests.Collections.EnumerableExtensionsFacts

### Platforms Affected ### 

- All

### Behavioral Changes ###

As the introduction of this class is new to the code base, there are no breaking changes or issues with regression. 

A simplistic overview of implementation is as follows:

**View**
```xaml
<ComboBox ItemsSource="{Bindng Items}" SelectedValuePath="Key" DisplayMemberPath="Value" />
<Button Command="{Binding AddItemCommandAsync}" Content="Add" />
<Button Command="{Binding RemoveItemCommandAsync}" Content="Remove" />
```
**ViewModel**
```csharp
public class MainViewModel : ViewModelBase
{
    public ObservableDictionary<int, string> Items { get; } = new ObservableDictionary<int, string>();

    public TaskCommand AddItemCommandAsync { get; }

    public TaskCommand RemoveItemCommandAsync { get; }

    public MainViewModel()
    {
        AddItemCommandAsync = new TaskCommand(OnAddItemAsync);
        RemoveItemCommandAsync = new TaskCommand(OnRemoveItemAsync);
    }

    protected override Task InitializeAsync()
    {
        items.Add(1, "Foo");
        items.Add(2, "Bar");

        return base.InitializeAsync();
    }

    private Task OnAddItemAsync()
    {
        int nextId = Items.Keys.Max() + 1;

        Items.Add(nextId, $"Item{nextId}");
    }

    private Task OnRemoveItemAsync()
    {
        int id = Items.Keys.LastOrDefault();

        Items.Remove(id);
    }
}
```

### Testing Procedure ###

Unit tests have been created to test all use cases for ObservableDictionary as well as standard use cases for ToObservableDictionary methods. There are no UI automation tests created to test this behavior.

### PR Checklist ###

- [x] I have included examples or tests
- [x] I have updated the change log
- [x] I am listed in the CONTRIBUTORS file
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
