### PR TITLE
illustrate bom issue by skipping it to pass test

### DIFF
--- a/src/Catel.Tests/Configuration/DynamicConfigurationFacts.cs
+++ b/src/Catel.Tests/Configuration/DynamicConfigurationFacts.cs
@@ -152,7 +152,7 @@ namespace Catel.Tests.Configuration
 
                 var outputXml = memoryStream.GetUtf8String();
 
-                await Verify(outputXml);
+                await Verify(outputXml.Substring(1));
             }
         }
 


### PR DESCRIPTION
not for merging. just to show that is the first invisible bom char is skipped, the test passes