### PR TITLE
fixes GetString to avoid a bom

### DIFF
--- a/src/Catel.Core/IO/Extensions/StreamExtensions.cs
+++ b/src/Catel.Core/IO/Extensions/StreamExtensions.cs
@@ -9,6 +9,7 @@ namespace Catel.IO
     using System;
     using System.IO;
     using System.Text;
+    using System.Threading.Tasks;
     using Collections;
 
     /// <summary>
@@ -62,8 +63,10 @@ namespace Catel.IO
             Argument.IsNotNull("stream", stream);
             Argument.IsNotNull("encoding", encoding);
 
-            var data = stream.ToByteArray();
-            return encoding.GetString(data, 0, data.Length);
+            stream.Position = 0;
+
+            using var reader = new StreamReader(stream, encoding);
+            return reader.ReadToEnd();
         }
     }
 }


### PR DESCRIPTION
this is an alternative to #1663 that fixes the underlying helper method.

Note that, if  StreamExtensions is intended to be a general purpose public api, it is problematic in other ways.

 * ToByteArray assume that position can be change on the stream. so will likely fail for non memory streams
 * doesnt have sync overloads