### PR TITLE
Issue #1987 Updating text color of InfoBarMessageControl header bar

### DIFF
--- a/src/Catel.MVVM/Themes/InfoBarMessageControl.generic.xaml
+++ b/src/Catel.MVVM/Themes/InfoBarMessageControl.generic.xaml
@@ -12,6 +12,7 @@
 	<SolidColorBrush x:Key="InfoBarMessageErrorTextBackgroundBrush" Color="LightYellow" />
 	<SolidColorBrush x:Key="InfoBarMessageErrorTextColorBrush" Color="Red" />
 	<SolidColorBrush x:Key="InfoBarMessageWarningTextColorBrush" Color="Orange" />
+	<SolidColorBrush x:Key="InfoBarMessageHeaderTextColorBrush" Color="Black" />
 
 	<!-- Style -->
     <Style x:Key="{x:Type local:InfoBarMessageControl}" TargetType="local:InfoBarMessageControl">
@@ -41,7 +42,10 @@
                                     <!-- Internal StackPanel, otherwise the whole control will have the background brush -->
                                     <StackPanel Background="{StaticResource InfoBarMessageBackgroundBrush}">
                                         <!-- Actual text -->
-                                        <TextBlock Padding="4,2,4,2" Text="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:InfoBarMessageControl}}, Path=InfoMessage}" />
+                                    <TextBlock Padding="4,2,4,2" 
+					                    Text="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:InfoBarMessageControl}}, Path=InfoMessage}"
+					                    Foreground="{StaticResource InfoBarMessageHeaderTextColorBrush}">
+                                    </TextBlock>
 
                                         <!-- Line -->
                                         <Line Name="infoBarSeparator" Margin="0" Stroke="{StaticResource InfoBarMessageSeparatorBrush}" 

--- a/src/Catel.MVVM/Themes/InfoBarMessageControl.generic.xaml
+++ b/src/Catel.MVVM/Themes/InfoBarMessageControl.generic.xaml
@@ -42,10 +42,10 @@
                                     <!-- Internal StackPanel, otherwise the whole control will have the background brush -->
                                     <StackPanel Background="{StaticResource InfoBarMessageBackgroundBrush}">
                                         <!-- Actual text -->
-                                    <TextBlock Padding="4,2,4,2" 
+                                    <TextBlock 
+                                        Padding="4,2,4,2" 
 					                    Text="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:InfoBarMessageControl}}, Path=InfoMessage}"
-					                    Foreground="{StaticResource InfoBarMessageHeaderTextColorBrush}">
-                                    </TextBlock>
+					                    Foreground="{StaticResource InfoBarMessageHeaderTextColorBrush}"/>
 
                                         <!-- Line -->
                                         <Line Name="infoBarSeparator" Margin="0" Stroke="{StaticResource InfoBarMessageSeparatorBrush}" 


### PR DESCRIPTION
### Description of Change ###

Explicitly setting the foreground color to a black brush to avoid any application level styles from changing the style of the info bar.

### Issues Resolved ### 
- fixes #1987

### API Changes ###

None

### Platforms Affected ### 
- WPF (Could be more Platforms Affected)

### Behavioral Changes ###

It is possible the text color of the InfoBarMessageControl could change.  

### Testing Procedure ###

I tested in the Orc Wizard example application and within an application I working on.  Both applications are Windows WPF.

### PR Checklist ###

- [No ] I have included examples or tests
- [No ] I have updated the change log
- [No ] I am listed in the CONTRIBUTORS file
- [Yes] Rebased on top of the target branch at time of PR
- [Yes] Changes adhere to coding standard
