### PR TITLE
Feature/xml serialization possible bugs

### DIFF
--- a/src/Catel.Tests/Runtime/Serialization/XmlSerialization/Models.cs
+++ b/src/Catel.Tests/Runtime/Serialization/XmlSerialization/Models.cs
@@ -1,0 +1,30 @@
+﻿namespace Namespace_1
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Xml.Serialization;
+    using Catel.Data;
+
+    public class InheritedFromModelBase : ModelBase
+    {
+        [XmlAttribute]
+        public string? Name { get; set; }
+    }
+
+    public class NotInheritedFromModelBase
+    {
+        public string? Name { get; set; }
+    }
+    
+    [Serializable]
+    public class DataItem
+    {
+        public string? Name { get; set; }
+    }
+
+    public class SerializableData
+    {
+        public List<DataItem> Items { get; set; } = new();
+        public Dictionary<string, DataItem> Roots { get; set; } = new();
+    }
+}

--- a/src/Catel.Tests/Runtime/Serialization/XmlSerialization/Models.cs
+++ b/src/Catel.Tests/Runtime/Serialization/XmlSerialization/Models.cs
@@ -22,6 +22,105 @@
         public string? Name { get; set; }
     }
 
+    public interface IDataItem
+    {
+        string? Name { get; set; }
+    }
+
+    [Serializable]
+    public class DataItemV : ModelBase, IDataItem
+    {
+        public string? Name
+        {
+            get { return GetValue<string?>(NameProperty); }
+            set { SetValue(NameProperty, value); }
+        }
+
+        public static readonly IPropertyData NameProperty = RegisterProperty("Name", string.Empty);
+
+        public IDataItem? First
+        {
+            get { return GetValue<IDataItem>(FirstProperty); }
+            set { SetValue(FirstProperty, value); }
+        }
+
+        public static readonly IPropertyData FirstProperty = RegisterProperty("First", default(IDataItem?));
+
+        public IDataItem? Second
+        {
+            get { return GetValue<IDataItem>(SecondProperty); }
+            set { SetValue(SecondProperty, value); }
+        }
+
+        public static readonly IPropertyData SecondProperty = RegisterProperty("Second", default(IDataItem?));
+    }
+
+    public class DataItemRPart
+    {
+        public string? Name { get; set; }
+
+        public IDataItem? Item { get; set; }
+    }
+
+    public class DataItemRPart2
+    {
+        public string? Name { get; set; }
+
+        public IDataItem? Item { get; set; }
+    }
+
+    [Serializable]
+    public class DataItemR : ModelBase, IDataItem
+    {
+        public DataItemR()
+        {
+            Parts = new List<DataItemRPart>();
+            Parts2 = new List<DataItemRPart2>();
+        }
+
+        public string? Name
+        {
+            get { return GetValue<string?>(NameProperty); }
+            set { SetValue(NameProperty, value); }
+        }
+
+        public static readonly IPropertyData NameProperty = RegisterProperty("Name", string.Empty);
+
+        public List<DataItemRPart> Parts
+        {
+            get { return GetValue<List<DataItemRPart>>(PartsProperty); }
+            set { SetValue(PartsProperty, value); }
+        }
+
+        public static readonly IPropertyData PartsProperty = RegisterProperty("Parts", default(List<DataItemRPart>));
+
+        public List<DataItemRPart2> Parts2
+        {
+            get { return GetValue<List<DataItemRPart2>>(Parts2Property); }
+            set { SetValue(Parts2Property, value); }
+        }
+
+        public static readonly IPropertyData Parts2Property = RegisterProperty("Parts2", default(List<DataItemRPart2>));
+    }
+
+    [Serializable]
+    public class DataItemD : ModelBase, IDataItem
+    {
+        public string? Name
+        {
+            get { return GetValue<string?>(NameProperty); }
+            set { SetValue(NameProperty, value); }
+        }
+
+        public static readonly IPropertyData NameProperty = RegisterProperty("Name", string.Empty);
+    }
+    
+    public class ContentData
+    {
+        public List<IDataItem> DataItems { get; set; } = new();
+        public Dictionary<string, IDataItem> Roots { get; set; } = new();
+    }
+
     public class SerializableData
     {
         public List<DataItem> Items { get; set; } = new();

--- a/src/Catel.Tests/Runtime/Serialization/XmlSerialization/XmlSerializationFacts.cs
+++ b/src/Catel.Tests/Runtime/Serialization/XmlSerialization/XmlSerializationFacts.cs
@@ -5,14 +5,15 @@
     using System.Collections.ObjectModel;
     using System.IO;
     using System.Linq;
+    using System.Threading.Tasks;
+    using System.Windows.Markup;
     using System.Xml.Serialization;
-    using Catel.Collections;
     using Catel.Data;
     using Catel.IoC;
-    using Catel.Logging;
     using Catel.Runtime.Serialization;
     using Catel.Runtime.Serialization.Xml;
     using Data;
+    using Namespace_1;
     using NUnit.Framework;
     using TestModels;
 
@@ -97,6 +98,53 @@
             }
 
             public static readonly IPropertyData LastNameProperty = RegisterProperty("LastName", string.Empty);
+        }
+
+        [TestFixture]
+        public class FailedTestFacts
+        {
+            [Test]
+            public async Task DictionaryWithItemsListSerializationTestAsync()
+            {
+                var serializableData = new SerializableData
+                {
+                    Items = new List<DataItem>
+                    {
+                        new()
+                    },
+
+                    Roots = new Dictionary<string, DataItem>
+                    {
+                        {
+                            "Key", new DataItem()
+                        }
+                    }
+                };
+
+                Assert.DoesNotThrow(() => SerializationTestHelper.SerializeAndDeserialize(serializableData, SerializationFactory.GetXmlSerializer()));
+            }
+
+            [Test]
+            public async Task SerializeInheritedFromModelBaseAsync()
+            {
+                var inheritedFromModelBase = new InheritedFromModelBase
+                {
+                    Name = "Inherited"
+                };
+
+                var inheritedFromModelBaseCopy = SerializationTestHelper.SerializeAndDeserialize(inheritedFromModelBase, SerializationFactory.GetXmlSerializer());
+
+
+                var notInheritedFromModelBase = new NotInheritedFromModelBase
+                {
+                    Name = "NotInherited"
+                };
+
+                var notInheritedFromModelBaseCopy = SerializationTestHelper.SerializeAndDeserialize(notInheritedFromModelBase, SerializationFactory.GetXmlSerializer());
+
+                Assert.IsNotNull(inheritedFromModelBaseCopy.Name);
+                Assert.IsNotNull(notInheritedFromModelBaseCopy.Name);
+            }
         }
 
         [TestFixture]

--- a/src/Catel.Tests/Runtime/Serialization/XmlSerialization/XmlSerializationFacts.cs
+++ b/src/Catel.Tests/Runtime/Serialization/XmlSerialization/XmlSerializationFacts.cs
@@ -145,6 +145,85 @@
                 Assert.IsNotNull(inheritedFromModelBaseCopy.Name);
                 Assert.IsNotNull(notInheritedFromModelBaseCopy.Name);
             }
+
+            [Test, Timeout(5000)]
+            public async Task HierarchyOfModelBaseObjectsTestAsync()
+            {
+                var itemD = new DataItemD
+                {
+                    Name = "Item D"
+                };
+
+                var itemR = new DataItemR
+                {
+                    Name = "Data item R",
+                    Parts = new List<DataItemRPart>
+                    {
+                        new()
+                        {
+                            Item = itemD,
+                            Name = "Parts"
+                        }
+                    },
+                };
+
+                var itemV = new DataItemV
+                {
+                    First = itemR,
+                    Second = itemD
+                };
+
+                var data = new ContentData
+                {
+                    DataItems = new List<IDataItem>
+                    {
+                        itemV,
+                        itemR,
+                        itemD
+                    },
+
+                    Roots = new Dictionary<string, IDataItem>
+                    {
+                        { "Key", itemV }
+                    }
+                };
+
+                var xmlSerializer = SerializationFactory.GetXmlSerializer();
+                var dataCopy = SerializationTestHelper.SerializeAndDeserialize(data, SerializationFactory.GetXmlSerializer());
+
+                //var tempFile = Path.Combine(Path.GetTempPath(), "Test.xml");
+                //try
+                //{
+                //    using (var fileStream = File.Create(tempFile))
+                //    {
+                //        xmlSerializer.Serialize(data, fileStream);
+                //    }
+
+                //    using (var newFileStream = File.OpenRead(tempFile))
+                //    {
+                //        try
+                //        {
+                //            var data2 = xmlSerializer.Deserialize<ContentData>(newFileStream);
+                //        }
+                //        catch (Exception e)
+                //        {
+                //            Console.WriteLine(e);
+                //            throw;
+                //        }
+                //    }
+                //}
+                //catch (Exception e)
+                //{
+                //    Assert.Fail(e.Message);
+                //}
+                //finally
+                //{
+                //    if (File.Exists(tempFile))
+                //    {
+                //        File.Delete(tempFile);
+                //    }
+                //}
+            }
         }
 
         [TestFixture]


### PR DESCRIPTION
Some possible bugs in Xml Serializer

1. DictionaryWithItemsListSerializationTestAsync - if we create class with property with name "Items" and property with type Dictionary, on serialization/deserialization it will fail because of hardcoded name "Items" for dictionary
2. SerializeInheritedFromModelBaseAsync - it might not be a bug, but behavior feels unexpected: if we inherit from ModelBase, not using Set/Get property inside getter and setter + don't have a Catel.Fody referenced - this property won't be serialized;
3. HierarchyOfModelBaseObjectsTestAsync - if we inherit from ModelBase and have a hierarchy (**with no loops**) of such objects sometimes serialization generates wrong results, and then deserialization goes to eternal loop
