### PR TITLE
Changed ValueConverterBase to use result of linked converter for validation

### DIFF
--- a/src/Catel.MVVM/MVVM/Converters/ValueConverterBase.cs
+++ b/src/Catel.MVVM/MVVM/Converters/ValueConverterBase.cs
@@ -106,7 +106,7 @@
                 returnValue = Link.Convert(returnValue, OverrideType ?? targetType, parameter, cultureToUse);
             }
 
-            if (!IsConvertable<TConvert>(value))
+            if (!IsConvertable<TConvert>(returnValue))
             {
                 Log.Warning("Cannot convert value of type '{0}', expected type '{1}', ignoring converter results",
                     ObjectToStringHelper.ToTypeString(returnValue), typeof(TConvert));
@@ -136,7 +136,7 @@
 
             var returnValue = value;
 
-            if (!IsConvertable<TConvertBack>(value))
+            if (!IsConvertable<TConvertBack>(returnValue))
             {
                 Log.Warning("Cannot convert back value of type '{0}', expected type '{1}', ignoring converter results",
                     ObjectToStringHelper.ToTypeString(returnValue), typeof(TConvertBack));

--- a/src/Catel.Tests/MVVM/Converters/ValueConverterBaseTests.cs
+++ b/src/Catel.Tests/MVVM/Converters/ValueConverterBaseTests.cs
@@ -1,0 +1,65 @@
+﻿namespace Catel.Tests.MVVM.Converters
+{
+    using System;
+    using Catel.MVVM.Converters;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ValueConverterBaseTest
+    {
+        #region Methods
+        [TestCase]
+        public void LinkConversion_ValidSetup()
+        {
+            var converterA = new ConverterA();
+            var converterB = new ConverterB();
+            converterB.Link = converterA;
+
+            var result = converterB.Convert(new A(), typeof(C), null, null);
+
+            Assert.IsInstanceOf<C>(result);
+        }
+
+        [TestCase]
+        public void LinkConversion_InvalidSetup()
+        {
+            var converterA = new ConverterA();
+            var converterB = new ConverterB();
+            converterA.Link = converterB;
+
+            var result = converterA.Convert(new A(), typeof(C), null, null);
+
+            Assert.AreEqual(result, ConverterHelper.UnsetValue);
+        }
+        
+        [TestCase]
+        public void LinkConversion_NoLink()
+        {
+            var converterB = new ConverterB();
+
+            var result = converterB.Convert(new A(), typeof(C), null, null);
+
+            Assert.AreEqual(result, ConverterHelper.UnsetValue);
+        }
+        #endregion
+
+        #region Helper Classes
+        private class A { }
+        private class B { }
+        private class C { }
+
+        private class ConverterA : ValueConverterBase<A, B>
+        {
+            protected override object? Convert(A value, Type targetType, object? parameter) => new B();
+            protected override object? ConvertBack(B? value, Type targetType, object? parameter) => new A();
+        }
+
+        private class ConverterB : ValueConverterBase<B, C>
+        {
+            protected override object? Convert(B? value, Type targetType, object? parameter) => new C();
+            protected override object? ConvertBack(C? value, Type targetType, object? parameter) => new B();
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
Modified Convert and ConvertBack to use the returnValue instead of value.

### Description of Change ###

Currently the convert-functions of the value converter uses the initial value for validation (IsConvertable). If a linked Converter is set, that converts the provided value to a valid type, the conversion still fails because the result of the link is not used for validation. 

### Issues Resolved ### 

None

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- WPF

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
