### PR TITLE
Change ConfigurationService to not store complex objects as a single string

### DIFF
--- a/src/Catel.Core/Configuration/ConfigurationService.cs
+++ b/src/Catel.Core/Configuration/ConfigurationService.cs
@@ -204,18 +204,17 @@
             var originalKey = key;
             key = GetFinalKey(key);
 
-            var stringValue = _objectConverterService.ConvertFromObjectToString(value, CultureInfo.InvariantCulture);
-            var existingValue = string.Empty;
+            object? existingValue;
 
             var lockObject = GetLockObject(container);
             using (lockObject.Lock())
             {
                 existingValue = GetValueFromStore(container, key);
 
-                SetValueToStore(container, key, stringValue);
+                SetValueToStore(container, key, value);
             }
 
-            if (!string.Equals(stringValue, existingValue))
+            if (!Equals(value, existingValue))
             {
                 RaiseConfigurationChanged(container, originalKey, value);
             }
@@ -407,7 +406,7 @@
         /// <param name="container">The container.</param>
         /// <param name="key">The key.</param>
         /// <param name="value">The value.</param>
-        protected virtual void SetValueToStore(ConfigurationContainer container, string key, string value)
+        protected virtual void SetValueToStore(ConfigurationContainer container, string key, object? value)
         {
             var lockObject = GetLockObject(container);
             using (lockObject.Lock())

--- a/src/Catel.Core/Configuration/ConfigurationService.cs
+++ b/src/Catel.Core/Configuration/ConfigurationService.cs
@@ -31,7 +31,7 @@
 
         private readonly IObjectConverterService _objectConverterService;
         private readonly ISerializer _serializer;
-        private readonly IAppDataService _appDataService; 
+        private readonly IAppDataService _appDataService;
         private readonly IDispatcherService _dispatcherService;
 
         private DynamicConfiguration? _localConfiguration;
@@ -161,7 +161,7 @@
 
             try
             {
-                var value = string.Empty;
+                object? value;
 
                 var lockObject = GetLockObject(container);
                 using (lockObject.Lock())
@@ -174,19 +174,12 @@
                     value = GetValueFromStore(container, key);
                 }
 
-                if (value is null)
+                return value switch
                 {
-                    return defaultValue;
-                }
-
-                // ObjectConverterService doesn't support object, but just return the value as is
-                if (typeof(T) == typeof(object))
-                {
-                    return (T)(object)value;
-                }
-
-                var finalValue = (T)_objectConverterService.ConvertFromStringToObject(value, typeof(T), CultureInfo.InvariantCulture)!;
-                return finalValue;
+                    null => defaultValue,
+                    string s => (T)_objectConverterService.ConvertFromStringToObject(s, typeof(T), CultureInfo.InvariantCulture)!,
+                    _ => (T)value
+                };
             }
             catch (Exception ex)
             {
@@ -385,7 +378,7 @@
         /// <param name="container">The container.</param>
         /// <param name="key">The key.</param>
         /// <returns>The value.</returns>
-        protected virtual string GetValueFromStore(ConfigurationContainer container, string key)
+        protected virtual object? GetValueFromStore(ConfigurationContainer container, string key)
         {
             var lockObject = GetLockObject(container);
             using (lockObject.Lock())
@@ -393,10 +386,10 @@
                 var settings = GetSettingsContainer(container);
                 if (settings is null)
                 {
-                    return string.Empty;
+                    return null;
                 }
 
-                return settings.GetConfigurationValue(key, string.Empty);
+                return settings.GetConfigurationValue(key);
             }
         }
 

--- a/src/Catel.Tests/Configuration/ConfigurationServiceFacts.cs
+++ b/src/Catel.Tests/Configuration/ConfigurationServiceFacts.cs
@@ -9,6 +9,7 @@
     using Catel.Runtime.Serialization.Xml;
     using Catel.IO;
     using System.IO;
+    using System.Runtime.Serialization;
     using System.Threading.Tasks;
 
     public partial class ConfigurationServiceFacts
@@ -54,6 +55,13 @@
             {
                 return await base.LoadConfigurationAsync(fileName);
             }
+        }
+        
+        [DataContract]
+        public class ComplexObject
+        {
+            [DataMember] public string ValueA { get; set; } = string.Empty;
+            [DataMember] public int ValueB { get; set; }
         }
 
         private static async Task<TestConfigurationService> GetConfigurationServiceAsync(string name = null)
@@ -125,11 +133,42 @@
 
             [TestCase(ConfigurationContainer.Local)]
             [TestCase(ConfigurationContainer.Roaming)]
+            public async Task ReturnsExistingComplexValueAsync(ConfigurationContainer container)
+            {
+                var configurationService = await GetConfigurationServiceAsync();
+                var testObject = new ComplexObject
+                {
+                    ValueA = "Test83123",
+                    ValueB = 42
+                };
+
+                configurationService.SetValue(container, "myComplexKey", testObject);
+
+                var result = configurationService.GetValue<ComplexObject>(container, "myComplexKey");
+                Assert.Multiple(() =>
+                {
+                    Assert.That(testObject.ValueA, Is.EqualTo(result.ValueA));
+                    Assert.That(testObject.ValueB, Is.EqualTo(result.ValueB));
+                });
+            }
+
+            [TestCase(ConfigurationContainer.Local)]
+            [TestCase(ConfigurationContainer.Roaming)]
             public async Task ReturnsDefaultValueForNonExistingValueAsync(ConfigurationContainer container)
             {
                 var configurationService = await GetConfigurationServiceAsync();
 
                 Assert.That(configurationService.GetValue(container, "nonExistingKey", "nonExistingValue"), Is.EqualTo("nonExistingValue"));
+            }
+
+            [TestCase(ConfigurationContainer.Local)]
+            [TestCase(ConfigurationContainer.Roaming)]
+            public async Task ReturnsDefaultValueForNonExistingComplexValueAsync(ConfigurationContainer container)
+            {
+                var configurationService = await GetConfigurationServiceAsync();
+                var defaultValue = new ComplexObject { ValueA = "Test8312", ValueB = 5421 };
+
+                Assert.That(configurationService.GetValue(container, "nonExistingKey", defaultValue), Is.EqualTo(defaultValue));
             }
 
             [TestCase(ConfigurationContainer.Local)]
@@ -174,6 +213,27 @@
                 configurationService.SetValue(container, "myKey", "myValue");
 
                 Assert.That(configurationService.GetValue<string>(container, "myKey"), Is.EqualTo("myValue"));
+            }
+
+            [TestCase(ConfigurationContainer.Local)]
+            [TestCase(ConfigurationContainer.Roaming)]
+            public async Task SetsComplexValueCorrectlyAsync(ConfigurationContainer container)
+            {
+                var configurationService = await GetConfigurationServiceAsync();
+                var testObject = new ComplexObject
+                {
+                    ValueA = "Test83123",
+                    ValueB = 42
+                };
+
+                configurationService.SetValue(container, "myComplexKey", testObject);
+
+                var result = configurationService.GetValue<ComplexObject>(container, "myComplexKey");
+                Assert.Multiple(() =>
+                {
+                    Assert.That(testObject.ValueA, Is.EqualTo(result.ValueA));
+                    Assert.That(testObject.ValueB, Is.EqualTo(result.ValueB));
+                });
             }
 
             [TestCase(ConfigurationContainer.Local)]

--- a/src/Catel.Tests/Configuration/ConfigurationServiceFacts.serialization.cs
+++ b/src/Catel.Tests/Configuration/ConfigurationServiceFacts.serialization.cs
@@ -32,7 +32,7 @@
                 {
                 }
 
-                protected override void SetValueToStore(ConfigurationContainer container, string key, object value)
+                protected override void SetValueToStore(ConfigurationContainer container, string key, object? value)
                 {
                     base.SetValueToStore(container, key, value);
 

--- a/src/Catel.Tests/Configuration/ConfigurationServiceFacts.serialization.cs
+++ b/src/Catel.Tests/Configuration/ConfigurationServiceFacts.serialization.cs
@@ -32,7 +32,7 @@
                 {
                 }
 
-                protected override void SetValueToStore(ConfigurationContainer container, string key, string value)
+                protected override void SetValueToStore(ConfigurationContainer container, string key, object value)
                 {
                     base.SetValueToStore(container, key, value);
 


### PR DESCRIPTION
### Description of Change ###

Changed how the ConfigurationService stores complex objects. The current version converts any object directly to string which effectively defaults to `ToString()`. This circumvents any possible serilization even though `DynamicConfiguration` supports it.
The new behaviour is to skip the string conversion and directly store the provided object.

### Issues Resolved ### 

<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###

<!-- List all API changes here (or just put None) -->
 
None

### Behavioral Changes ###

Classes that are serializable are stored as serialized xml instead of a string value

### Testing Procedure ###

<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] I have included examples or tests
- [ ] I have updated the change log or created a GitHub ticket with the change
- [ ] I am listed in the CONTRIBUTORS file (if it exists)
- [ ] Changes adhere to coding standard
- [ ] I checked the licenses of Third Party software and discussed new dependencies with at least 1 other team member